### PR TITLE
fix Chrome autofilling login into queue filter or newchat input

### DIFF
--- a/css/looks.css
+++ b/css/looks.css
@@ -1060,6 +1060,9 @@ a.importLinkCheck {
   flex: 1;
 }
 #newchat {
+  width: 100%;
+}
+#newchatForm {
   flex: 1;
   margin-right: var(--pad1);
 }

--- a/index.html
+++ b/index.html
@@ -114,7 +114,9 @@
 				</div>
 			</div>
 			<div id="chatbottom">
+				<form id="newchatForm" autocomplete="off" onsubmit="return false;">
 				<input maxlength="240" autocomplete="off" name="newchat" placeholder="Chat a thing" type="text" id="newchat" tabindex="0">
+				</form>
 				<button role="button" class="butt graybutt iconbutt" id="pickEmoji"><i class="material-icons"> insert_emoticon </i></button>
 				<div id="emojiPicker">
 					<div id="pickerNav">
@@ -207,7 +209,9 @@
 					</div>
 				</div>
 				<div id="filterMachine">
+					<form id="queueFilterForm" autocomplete="off" onsubmit="return false;">
 					<input type="text" autocomplete="off" placeholder="Filter your list..." name="queueFilter" id="queueFilter">
+					</form>
 				</div>
 			</div>
 			<div id="queuelist" class="scrollit">


### PR DESCRIPTION
This is the only way I could find to fix this issue for me. By adding a form tag around the inputs, the autocomplete started to work. The **onsubmit** is to stop the form from being submitted when you hit enter with an empty input.

Fixes #85 