### PR TITLE
reset the history steal button after 3 seconds

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1295,6 +1295,10 @@ firetable.actions = {
     $("#apv" + type + cid).find(".material-icons").text("check");
     $("#apv" + type + cid).css("color", firetable.orange);
     $("#apv" + type + cid).css("pointer-events", "none");
+    setTimeout( function() {
+      $("#apv" + type + cid).find(".material-icons").text("playlist_add");
+      $("#apv" + type + cid).removeAttr("style");
+    }, 3000 );
     var cuteid = firetable.queueRef.push(info, function() {
       firetable.debug && console.log('queue track id:',cuteid.key);
       if (!tobottom) firetable.actions.bumpSongInQueue(cuteid.key);


### PR DESCRIPTION
Re-adds the pointer events and icon back to the history item after 3 seconds, so that you can add the song to other playlists.

Fixes #31 