### PR TITLE
#33

### DIFF
--- a/css/looks.css
+++ b/css/looks.css
@@ -1599,7 +1599,7 @@ html .ui-button.ui-state-disabled:active {
 
 #fyre {
     position: absolute;
-    bottom: -2rem;
+    bottom: -4rem;
     left: 50%;
     width: min(22rem, 60%);
     height: 14rem;
@@ -2916,7 +2916,100 @@ img.emoji,
 #cardsMain {
     display: grid;
     grid-gap: 0.625rem;
-    grid-template-columns: repeat(auto-fill, minmax(12rem, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));
+}
+
+#cardStats {
+    grid-column: 1 / -1;
+    display: flex;
+    flex-direction: column;
+    gap: var(--pad2);
+    padding: var(--pad3);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    background-color: var(--color-bg-t1);
+}
+
+.cardStatsSummary {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(7rem, 1fr));
+    gap: var(--pad2);
+}
+
+.cardStatTile {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    padding: var(--pad2);
+    border-radius: var(--radius-sm);
+    background-color: var(--color-bg-s2);
+}
+
+.cardStatLabel {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--color-text-muted);
+}
+
+.cardStatValue {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: var(--color-text-light);
+}
+
+.cardStatDjBreakdown {
+    display: flex;
+    flex-direction: column;
+    gap: var(--pad1);
+}
+
+#cardStats .hist-day-header {
+    position: static;
+    top: auto;
+}
+
+#cardStats .hist-day-items.cardStatDjList {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.4rem;
+    padding-left: 0;
+}
+
+#cardStats .hist-day-group.collapsed .hist-day-items.cardStatDjList {
+    display: none;
+}
+
+#cardStats .hist-day-items.cardStatDjList::before {
+    content: none;
+}
+
+.cardStatDjRow {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.3rem 0.5rem;
+    border-radius: 999px;
+    background-color: var(--color-bg-s2);
+    border: 1px solid var(--color-border);
+}
+
+.cardStatDjName {
+    color: var(--color-text);
+    font-size: 0.75rem;
+}
+
+.cardStatDjCount {
+    min-width: 1.25rem;
+    text-align: center;
+    border-radius: 999px;
+    padding: 0.1rem 0.35rem;
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: #000;
+    background-color: var(--color-orange);
 }
 
 .cardsEmpty {
@@ -2947,7 +3040,8 @@ img.emoji,
 }
 
 span.cardShareChat,
-span.cardGiftChat {
+span.cardGiftChat,
+span.cardViewLarger {
     position: absolute;
     font-size: 0.875rem;
     background-color: #000;
@@ -2957,13 +3051,18 @@ span.cardGiftChat {
 }
 
 span.cardShareChat {
-    top: 33%;
+    top: 25%;
 }
 
 span.cardGiftChat {
-    bottom: 33%;
+    top: 42%;
 }
 
+span.cardViewLarger {
+    top: 59%;
+}
+
+span.cardViewLarger:hover,
 span.cardGiftChat:hover,
 span.cardShareChat:hover {
     background-color: var(--color-orange);
@@ -2971,8 +3070,36 @@ span.cardShareChat:hover {
 }
 
 .caseCardSpot:hover .cardShareChat,
-.caseCardSpot:hover .cardGiftChat {
+.caseCardSpot:hover .cardGiftChat,
+.caseCardSpot:hover .cardViewLarger {
     display: block;
+}
+
+/* ── View Larger modal ── */
+#cardViewLargerModal {
+    position: relative;
+    background: transparent;
+    align-items: stretch;
+    justify-content: flex-start;
+    width: min(92vw, calc(92vh * (225 / 300)));
+    max-height: 92vh;
+    padding: var(--pad3);
+    box-sizing: border-box;
+    gap: var(--pad2);
+    background-color: var(--color-bg-s2);
+}
+
+#cardViewLargerModal #cardViewLargerClose {
+    align-self: flex-end;
+    margin: 0;
+}
+
+#cardViewLargerCanvas {
+    display: block;
+    width: 100%;
+    height: auto;
+    max-height: calc(92vh - 4.5rem);
+    aspect-ratio: 225 / 300;
 }
 
 #importDubContent {

--- a/css/looks.css
+++ b/css/looks.css
@@ -1065,15 +1065,17 @@ a.sociallogo[href] {
 
 .blockon {
     display: none;
-    width: 2.2rem;
-    height: 2.2rem;
-    font-size: 2.2rem;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    font-size: 1.67rem;
     background-color: rgba(0, 0, 0, 0.5);
-    color: var(--color-orange);
+    color: rgba(222 55 0);
     border-radius: var(--radius-pill);
 }
 .prson.blockd .blockon {
-    display: block;
+    display: flex;
 }
 .blockon:empty {
     display: none;

--- a/css/looks.css
+++ b/css/looks.css
@@ -2703,6 +2703,35 @@ img.emoji,
     font-size: 0.8rem;
     font-weight: 500;
     line-height: 1.3;
+    display: flex;
+    align-items: flex-start;
+    gap: 0.25rem;
+}
+#thediscovers .listwords .histlink {
+    flex: 1;
+}
+#thediscovers .listwords .butt {
+    align-self: flex-start;
+    flex-shrink: 0;
+    min-width: 0;
+    min-height: 0;
+    height: auto;
+    font-size: 1.25rem;
+    background: none;
+    border: none;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    padding: 0;
+    line-height: 1.1;
+    box-shadow: none;
+}
+#thediscovers .listwords .butt:hover {
+    color: var(--color-text-light);
+}
+#thediscovers .discart .previewicon {
+    width: 3rem;
+    height: 3rem;
+    font-size: 2rem;
 }
 
 #thediscovers .histlink {
@@ -2712,6 +2741,7 @@ img.emoji,
 #thediscovers .fresh-track-title,
 #thediscovers .fresh-track-artist {
     display: block;
+    text-wrap: balance;
 }
 
 #thediscovers .fresh-track-title {

--- a/css/looks.css
+++ b/css/looks.css
@@ -393,7 +393,7 @@ code {
     background: rgba(255, 255, 255, 0.12);
 }
 .djplaque .deckDepartureBtn.on {
-    color: var(--color-orange);
+    color: white;
     background: transparent;
     border: none;
     box-shadow: none;
@@ -1463,10 +1463,22 @@ html .ui-button.ui-state-disabled:active {
     justify-content: flex-end;
     position: relative;
     overflow: hidden;
+    background: linear-gradient(to bottom, color-mix(in srgb, transparent 85%, var(--color-accent)), color-mix(in srgb, transparent 66%, var(--color-accent)));
     border-top-left-radius: 1.5rem;
     border-top-right-radius: 1.5rem;
-    box-shadow: inset 0 -4rem 4rem -3rem rgba(0, 0, 0, 0.5), inset 0 16rem 32rem -3rem rgba(0, 0, 0, 0.75),
-        inset 0 4rem 2rem -4rem black;
+    box-shadow: inset 0 0 8rem -7rem var(--color-accent), 0 0 2rem -1rem black;
+
+    &::before {
+        content: "";
+        position: absolute;
+        inset: 0;
+        background-image: url(../img/idlogo2.png);
+        background-repeat: no-repeat;
+        background-position: center;
+        background-size: contain;
+        pointer-events: none;
+        opacity: 0.05;
+    }
 }
 
 #deck {
@@ -1574,51 +1586,6 @@ html .ui-button.ui-state-disabled:active {
     transition: top 2s ease-in-out;
     pointer-events: none;
 }
-
-@keyframes ft-eq-bounce {
-    0%, 100% { height: 15%; }
-    50%       { height: 85%; }
-}
-
-#ft-eq {
-    position: absolute;
-    inset: 0;
-    display: flex;
-    align-items: flex-end;
-    justify-content: space-around;
-    gap: 0.5rem;
-    padding: 0.5rem;
-    box-sizing: border-box;
-    z-index: 0;
-    background-color: rgba(0, 0, 0, 0.95);
-    background-image: url(../img/idlogo2.png);
-    background-size: 100%;
-    background-repeat: no-repeat;
-    background-position: center;
-    background-blend-mode: hue;
-}
-
-.ft-eq-bar {
-    flex: 1;
-    min-height: 15%;
-    background-color: var(--color-accent);
-    animation: ft-eq-bounce 10s ease-in-out infinite;
-    transform: scaleX(3) scaleY(3);
-    filter: blur(150px);
-}
-
-.ft-eq-bar:nth-child(1)  { animation-duration: 11s; animation-delay: 0s; background-color: color-mix(in srgb, var(--color-accent) 80%, rebeccapurple 20%); }
-.ft-eq-bar:nth-child(2)  { animation-duration: 07s; animation-delay: -03s; background-color: color-mix(in srgb, var(--color-accent) 80%, cyan 20%); }
-.ft-eq-bar:nth-child(3)  { animation-duration: 13s; animation-delay: -06s; background-color: color-mix(in srgb, var(--color-accent) 80%, deepskyblue 20%); }
-.ft-eq-bar:nth-child(4)  { animation-duration: 08s; animation-delay: -01s; background-color: color-mix(in srgb, var(--color-accent) 80%, lime 20%); }
-.ft-eq-bar:nth-child(5)  { animation-duration: 10s; animation-delay: -04.5s; background-color: color-mix(in srgb, var(--color-accent) 80%, orange 20%); }
-.ft-eq-bar:nth-child(6)  { animation-duration: 06s; animation-delay: -02s;  background-color: color-mix(in srgb, var(--color-accent) 80%, yellow 20%); }
-.ft-eq-bar:nth-child(7)  { animation-duration: 12s; animation-delay: -05.5s; background-color: color-mix(in srgb, var(--color-accent) 80%, magenta 20%); }
-.ft-eq-bar:nth-child(8)  { animation-duration: 07.5s; animation-delay: -03.5s; background-color: color-mix(in srgb, var(--color-accent) 80%, deeppink 20%); }
-.ft-eq-bar:nth-child(9)  { animation-duration: 10.5s; animation-delay: -01.5s; background-color: color-mix(in srgb, var(--color-accent) 80%, violet 20%); }
-.ft-eq-bar:nth-child(10) { animation-duration: 08.5s; animation-delay: -05s;  background-color: color-mix(in srgb, var(--color-accent) 80%, indigo 20%); }
-.ft-eq-bar:nth-child(11) { animation-duration: 11.5s; animation-delay: -02.5s; background-color: color-mix(in srgb, var(--color-accent) 80%, blue 20%); }
-.ft-eq-bar:nth-child(12) { animation-duration: 06.5s; animation-delay: -04s;  background-color: color-mix(in srgb, var(--color-accent) 80%, navy 20%); }
 
 #scScreen,
 #playerArea {
@@ -2037,14 +2004,11 @@ a.importLinkCheck {
 #newchatForm {
     grid-column: 2/3;
     width: 100%;
-    padding-right: var(--pad4);
 }
 
 .newChat {
     position: relative;
-    display: grid;
-    grid-template-columns: auto 1fr auto;
-    grid-template-rows: auto auto;
+    display: flex;
     gap: var(--pad2);
     margin: var(--pad3);
     color: var(--color-text);
@@ -2083,10 +2047,6 @@ a.importLinkCheck {
     font-size: 0.75rem;
 }
 
-.npmsg {
-    grid-column: 1 / -1;
-}
-
 .npmsg-fires {
     position: absolute;
     z-index: 2;
@@ -2098,10 +2058,7 @@ a.importLinkCheck {
 }
 
 .chatContent {
-    grid-column: 2 / -1;
-    grid-row: 1 / -1;
-    display: grid;
-    grid-template-columns: subgrid;
+    flex: 1;
 }
 
 .chatContent .utitle {
@@ -2157,8 +2114,8 @@ a.importLinkCheck {
 }
 
 .chatText {
-    grid-column: 1 / -1;
     position: relative;
+    width: 100%;
     font-size: 0.8125rem;
     font-weight: 300;
     color: rgba(255, 255, 255, 0.8);
@@ -2250,8 +2207,6 @@ a.importLinkCheck {
 }
 
 .chatTime {
-    grid-column: 3 / -1;
-    grid-row: 1 / 2;
     position: relative;
     z-index: 2;
     font-size: 0.66rem;
@@ -3496,12 +3451,11 @@ body.blog {
         margin-bottom: 0.5rem;
     }
 
-    /* #idtitle {
-        display: block;
-    } */
+    #newchatForm {
+        padding-right: var(--pad4);
+    }
 
     #actualChat {
-        min-width: 20rem;
         max-width: 28rem;
     }
 

--- a/css/looks.css
+++ b/css/looks.css
@@ -904,16 +904,23 @@ a.sociallogo[href] {
 }
 
 #allUsers {
-    display: grid;
-    grid-template-columns: auto auto 1fr;
-    align-items: center;
-    gap: var(--pad2);
+    display: flex;
+    flex-direction: column;
     padding: var(--pad4);
 }
 
-#allUsers > *,
+#allUsers > * {
+    display: flex;
+    flex-direction: column;
+}
+
 #allUsers .prson {
-    display: contents;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: var(--pad2);
+    padding: var(--pad1) 0;
+    cursor: pointer;
 }
 
 #allUsers #userKEY.prson {
@@ -1011,7 +1018,8 @@ a.sociallogo[href] {
 .prsnNameRole {
     display: flex;
     align-items: center;
-    margin-left: 0.25rem;
+    flex: 1;
+    min-width: 0;
     font-size: 1rem;
     font-weight: 100;
 }
@@ -3256,7 +3264,7 @@ body.blog {
     top: 0;
     left: 0;
     z-index: 9999;
-    background-color: var(--color-bg-s2);
+    background-color: var(--color-bg-t3);
     color: var(--color-text-light);
     padding: 0.2rem 0.5rem;
     border-radius: var(--radius-sm);
@@ -3271,6 +3279,54 @@ body.blog {
 
 #ft-tooltip.is-visible {
     opacity: 1;
+}
+
+#ft-user-tip {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 9999;
+    background-color: var(--color-bg-t3);
+    color: var(--color-text-light);
+    padding: 0.5rem 0.65rem;
+    border-radius: var(--radius-sm);
+    font-size: 0.8rem;
+    pointer-events: none;
+    min-width: 11rem;
+    box-shadow: 0 2px 8px black;
+    visibility: hidden;
+    opacity: 0;
+    transition: opacity 120ms ease;
+
+    p {
+        font-size: 0.75rem;
+        color: var(--color-text-dim);
+        text-align: center;
+    }
+}
+
+#ft-user-tip.is-visible {
+    opacity: 1;
+}
+
+#ft-user-tip-arrow {
+    position: absolute;
+    width: 0.5rem;
+    height: 0.5rem;
+    background: var(--color-bg-t3);
+    transform: rotate(45deg);
+    pointer-events: none;
+}
+
+#ft-user-tip .utt-fact {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    line-height: 1.7;
+}
+
+#ft-user-tip .utt-label {
+    color: var(--color-text-muted);
 }
 
 /* ============================================
@@ -3598,25 +3654,13 @@ body.blog {
     }
 
     #allUsers {
-        grid-template-columns: 1fr auto auto;
-        grid-auto-flow: dense;
         padding-top: var(--pad5);
     }
-    #allUsers .ft-avatar {
-        grid-column: -2 / -1;
-    }
-    #allUsers .prsnRole {
-        grid-column: -3 / -2;
-    }
-    #allUsers .djOrder {
-        grid-column: 1 / 2;
+    #allUsers .prson {
+        flex-direction: row-reverse;
     }
     #allUsers .prsnNameRole {
-        grid-column: 1 / 2;
         justify-content: flex-end;
-    }
-    #allUsers .prsnName {
-        order: 2;
     }
 
     .newChat {

--- a/css/looks.css
+++ b/css/looks.css
@@ -106,8 +106,8 @@ body {
     margin: 0;
     font-size: 1rem;
     color: var(--color-text);
-    background: var(--color-bg);
-    background: linear-gradient(var(--color-bg-t1), var(--color-bg));
+    background-color: var(--color-bg);
+    background-image: linear-gradient(var(--color-bg-t1), var(--color-bg));
     overflow: hidden;
 }
 

--- a/css/looks.css
+++ b/css/looks.css
@@ -2037,6 +2037,7 @@ a.importLinkCheck {
 #newchatForm {
     grid-column: 2/3;
     width: 100%;
+    padding-right: var(--pad4);
 }
 
 .newChat {
@@ -3662,7 +3663,7 @@ body.blog {
     }
 
     .newChat {
-        margin-left: var(--pad4);
+        margin-inline: var(--pad4);
     }
 
     .nowplayn {

--- a/css/looks.css
+++ b/css/looks.css
@@ -2589,10 +2589,6 @@ img.emoji,
     height: 100%;
 }
 
-#mainGrid.view-discover #discover {
-    display: flex;
-}
-
 #mainGrid.login.view-discover #discover {
     grid-area: login;
     display: flex;

--- a/css/looks.css
+++ b/css/looks.css
@@ -1475,7 +1475,7 @@ html .ui-button.ui-state-disabled:active {
         background-image: url(../img/idlogo2.png);
         background-repeat: no-repeat;
         background-position: center;
-        background-size: contain;
+        background-size: cover;
         pointer-events: none;
         opacity: 0.05;
     }

--- a/css/looks.css
+++ b/css/looks.css
@@ -1552,16 +1552,21 @@ html .ui-button.ui-state-disabled:active {
     padding: 0.5rem;
     box-sizing: border-box;
     z-index: 0;
+    background-color: rgba(0, 0, 0, 0.9);
+    background-image: url(../img/idlogo2.png);
+    background-size: 100%;
+    background-repeat: no-repeat;
+    background-position: center;
+    background-blend-mode: hue;
 }
 
 .ft-eq-bar {
     flex: 1;
     min-height: 15%;
     background-color: var(--color-accent);
-    opacity: 0.25;
     animation: ft-eq-bounce 10s ease-in-out infinite;
-    transform: scaleX(2) scaleY(2);
-    filter: blur(50px);
+    transform: scaleX(3) scaleY(3);
+    filter: blur(150px);
 }
 
 .ft-eq-bar:nth-child(1)  { animation-duration: 11s; animation-delay: 0s; background-color: color-mix(in srgb, var(--color-accent) 80%, rebeccapurple 20%); }

--- a/css/looks.css
+++ b/css/looks.css
@@ -428,7 +428,7 @@ code {
 }
 
 .graybutt {
-    color: var(--color-text-muted);
+    color: rgba(255, 255, 255, 0.55);
     background: rgba(255, 255, 255, 0.05);
 }
 
@@ -457,9 +457,10 @@ code {
 .iconbutt.on {
     color: var(--color-orange);
     background: rgba(255, 255, 255, 0.033);
-    border-top: 1px solid black;
-    border-bottom: 1px solid var(--color-orange66);
-    box-shadow: inset 0 0 1rem var(--color-orange33);
+    border-top: 1px solid rgba(88, 88, 88, 0.5);
+    border-bottom: 1px solid rgba(0, 0, 0, 0.5);
+    box-shadow: inset 0 0 1rem rgba(123, 123, 123, 0.125);
+    text-shadow: 0 0 1rem black;
 }
 
 #fire.on {
@@ -973,15 +974,15 @@ a.sociallogo[href] {
     display: flex;
     align-items: center;
     margin-left: 0.25rem;
-    font-size: 0.875rem;
-    font-weight: 400;
+    font-size: 1rem;
+    font-weight: 100;
 }
 .prson.blockd .prsnNameRole {
     opacity: 0.5;
 }
 
 .prsnName {
-    font-weight: 500;
+    font-weight: 300;
     color: var(--color-text);
     white-space: nowrap;
     overflow-x: hidden;
@@ -1057,8 +1058,8 @@ a.sociallogo[href] {
     display: flex;
     align-items: center;
     position: relative;
-    width: 1.5rem;
-    height: 1.5rem;
+    width: 2rem;
+    height: 2rem;
     background-position: 50% 72%;
 }
 
@@ -2007,8 +2008,9 @@ a.importLinkCheck {
 .newChat .ft-avatar {
     position: relative;
     z-index: 2;
-    width: 2rem;
-    height: 2rem;
+    margin-top: 0.125rem;
+    width: 1.75rem;
+    height: 1.75rem;
     cursor: pointer;
 }
 
@@ -2057,16 +2059,21 @@ a.importLinkCheck {
 }
 
 .chatContent .utitle {
-    position: absolute;
-    z-index: 2;
-    left: -1.5rem;
+    flex: 0 0 auto;
+    font-size: 1em;
+    margin-left: 0.25em;
     color: var(--color-text-dim);
+}
+
+.chatContent .utitle:empty {
+    display: none;
 }
 
 .chatHead {
     position: relative;
     display: flex;
     align-items: center;
+    gap: 0;
 }
 
 .chatHead::after {
@@ -2078,7 +2085,7 @@ a.importLinkCheck {
 }
 
 .chatName {
-    margin-right: var(--pad1);
+    flex: 0 0 auto;
     font-size: 0.75rem;
     font-weight: 500;
     color: rgba(255, 255, 255, 0.4);
@@ -2104,9 +2111,11 @@ a.importLinkCheck {
 }
 
 .chatText {
-    position: relative;
-    font-size: 0.75rem;
     grid-column: 1 / -1;
+    position: relative;
+    font-size: 0.8125rem;
+    font-weight: 300;
+    color: rgba(255, 255, 255, 0.8);
 }
 
 .chatText.deleteMe:hover {

--- a/css/looks.css
+++ b/css/looks.css
@@ -61,7 +61,7 @@
     --pad6: 8rem;
 
     /* Layout */
-    --height-footer: 3rem;
+    --height-footer: 3.5rem;
 
     /* Radii */
     --radius-sm: 0.25rem;
@@ -2241,6 +2241,46 @@ a.importLinkCheck {
     gap: 0.5rem;
     height: var(--height-footer);
     padding-right: var(--pad3);
+}
+
+#typing-indicator {
+    padding-top: var(--pad1);
+    font-size: 0.7rem;
+    color: var(--color-text-muted);
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    max-width: 54ch;
+    margin-inline: auto;
+    width: 100%;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+
+    &:empty { min-height: 0; padding: 0; }
+}
+
+.typing-dots {
+    display: inline-flex;
+    gap: 2px;
+    flex-shrink: 0;
+}
+
+.typing-dots span {
+    display: block;
+    width: 4px;
+    height: 4px;
+    border-radius: 50%;
+    background: var(--color-text-muted);
+    animation: typing-bounce 1.2s ease-in-out infinite;
+}
+
+.typing-dots span:nth-child(2) { animation-delay: 0.2s; }
+.typing-dots span:nth-child(3) { animation-delay: 0.4s; }
+
+@keyframes typing-bounce {
+    0%, 60%, 100% { transform: translateY(0); opacity: 0.4; }
+    30%            { transform: translateY(-4px); opacity: 1; }
 }
 
 #pickEmoji {

--- a/css/looks.css
+++ b/css/looks.css
@@ -2653,7 +2653,8 @@ img.emoji,
 }
 
 #thediscovers .qtxt {
-    display: block;
+    display: flex;
+    flex-direction: column;
     flex: 1;
 }
 
@@ -2661,16 +2662,93 @@ img.emoji,
     font-size: 0.8rem;
     font-weight: 500;
     line-height: 1.3;
-    overflow: hidden;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
+}
+
+#thediscovers .histlink {
+    display: block;
+}
+
+#thediscovers .fresh-track-title,
+#thediscovers .fresh-track-artist {
+    display: block;
+}
+
+#thediscovers .fresh-track-title {
+    font-size: 1rem;
+    font-weight: 300;
+    color: var(--color-text-light);
+}
+
+#thediscovers .fresh-track-artist {
+    font-size: 0.75rem;
+    font-weight: 300;
+    color: var(--color-text);
+}
+
+#thediscovers .fresh-meta {
+    margin-top: auto;
+    padding-top: var(--pad1);
+    display: flex;
+    align-items: center;
+    width: 100%;
+    gap: 0.35rem;
+}
+
+#thediscovers .fresh-dj-avatar {
+    order: 3;
+    width: 1.35rem;
+    height: 1.35rem;
+    background-size: auto 140%;
+    background-position: center 60%;
+    margin-left: auto;
+    flex-shrink: 0;
+    overflow: visible;
+}
+
+#thediscovers .fresh-dj-avatar[data-label] {
+    position: relative;
+}
+
+#thediscovers .fresh-dj-avatar[data-label]::after {
+    content: attr(data-label);
+    position: absolute;
+    right: 0;
+    bottom: calc(100% + 0.4rem);
+    padding: 0.2rem 0.5rem;
+    font-size: 0.7rem;
+    font-family: var(--font-family);
+    white-space: nowrap;
+    color: var(--color-text-light);
+    background: var(--color-bg-t2);
+    border-radius: var(--radius-sm);
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 150ms ease;
+    z-index: 100;
+}
+
+#thediscovers .fresh-dj-avatar[data-label]:hover::after {
+    opacity: 1;
+}
+
+#thediscovers .histdj,
+#thediscovers .histdate,
+#thediscovers .histtime {
+    font-size: 0.7rem;
+    color: var(--color-text-muted);
+    margin-top: 0;
+}
+
+#thediscovers .histdate {
+    order: 1;
+}
+
+#thediscovers .histtime {
+    order: 2;
 }
 
 #thediscovers .histdj {
-    font-size: 0.7rem;
-    color: var(--color-text-dim);
-    margin-top: var(--pad1);
+    display: none;
 }
 
 /* ============================================

--- a/css/looks.css
+++ b/css/looks.css
@@ -3491,7 +3491,7 @@ body.blog {
     #mainGrid.mmchat,
     #mainGrid.mmusrs {
         grid-template-rows: auto 1fr;
-        grid-template-columns: min-content minmax(min-content, auto) min-content minmax(min-content, auto);
+        grid-template-columns: min-content 20vw min-content 30vw;
         grid-template-areas:
             "head people stage chat"
             "head people view  chat";
@@ -3564,7 +3564,6 @@ body.blog {
 
     #allUsersWrap {
         align-self: flex-end;
-        transform: translateX(1vw);
     }
 
     #usersWaitlist {

--- a/css/looks.css
+++ b/css/looks.css
@@ -365,8 +365,43 @@ code {
 }
 
 .removemeIcon {
+    grid-area: 1 / 1;
+    justify-self: start;
     font-size: 1rem;
-    vertical-align: middle;
+    line-height: 1.5rem;
+}
+
+.djplaque .deckDepartureBtn {
+    grid-area: 1 / 1;
+    justify-self: start;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 1.5rem;
+    height: 1.5rem;
+    padding: 0;
+    background: transparent;
+    border: none;
+    color: rgba(255, 255, 255, 0.4);
+    cursor: pointer;
+    border-radius: var(--radius-sm);
+    box-shadow: none;
+}
+.djplaque .deckDepartureBtn:hover {
+    color: #fff;
+    background: rgba(255, 255, 255, 0.12);
+}
+.djplaque .deckDepartureBtn.on {
+    color: var(--color-orange);
+    background: transparent;
+    border: none;
+    box-shadow: none;
+    text-shadow: none;
+}
+.djplaque .deckDepartureBtn i {
+    font-size: 0.9rem;
+    pointer-events: none;
 }
 
 .djplaque .deckRemoveBtn {
@@ -558,7 +593,6 @@ code {
     margin-left: var(--pad3);
 }
 
-#viewnav .header_icon .material-symbols-outlined,
 #viewnav .header_icon .material-symbols-outlined {
     font-size: 1.75rem;
 }
@@ -647,6 +681,10 @@ a.sociallogo[href] {
     background: none;
     border: 0;
     box-shadow: none;
+
+    &#cardcase i {
+        transform: rotate(180deg);
+    }
 }
 
 .header_icon .material-symbols-outlined,
@@ -1552,7 +1590,7 @@ html .ui-button.ui-state-disabled:active {
     padding: 0.5rem;
     box-sizing: border-box;
     z-index: 0;
-    background-color: rgba(0, 0, 0, 0.9);
+    background-color: rgba(0, 0, 0, 0.95);
     background-image: url(../img/idlogo2.png);
     background-size: 100%;
     background-repeat: no-repeat;

--- a/css/looks.css
+++ b/css/looks.css
@@ -3291,7 +3291,6 @@ body.blog {
     padding: 0.5rem 0.65rem;
     border-radius: var(--radius-sm);
     font-size: 0.8rem;
-    pointer-events: none;
     min-width: 11rem;
     box-shadow: 0 2px 8px black;
     visibility: hidden;
@@ -3302,6 +3301,29 @@ body.blog {
         font-size: 0.75rem;
         color: var(--color-text-dim);
         text-align: center;
+    }
+
+    .utt-actions {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        margin-top: 0.4rem;
+
+        &:empty { display: none; }
+    }
+
+    .utt-action-btn {
+        width: 100%;
+        padding: 0.25rem 0.5rem;
+        font-size: 0.75rem;
+        background-color: var(--color-bg-t1);
+        color: var(--color-text-light);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        text-align: left;
+
+        &:hover { background-color: var(--color-bg-t2); }
     }
 }
 

--- a/css/looks.css
+++ b/css/looks.css
@@ -1484,6 +1484,9 @@ html .ui-button.ui-state-disabled:active {
 #deck {
     grid-area: deck;
     display: flex;
+    justify-content: center;
+    gap: var(--pad1);
+    padding-inline: var(--pad1);
     max-width: 100vw;
 }
 
@@ -1498,8 +1501,7 @@ html .ui-button.ui-state-disabled:active {
     display: flex;
     flex-direction: column;
     justify-content: flex-end;
-    margin-right: var(--pad2);
-    margin-left: var(--pad2);
+    max-width: 10rem;
     min-width: 0;
 }
 
@@ -1531,7 +1533,7 @@ html .ui-button.ui-state-disabled:active {
     grid-template-rows: 1fr;
     align-items: center;
     min-width: 0;
-    padding: 0 var(--pad2);
+    padding: 0 var(--pad1);
     font-size: 0.75rem;
     line-height: 1.5rem;
     color: #fff;
@@ -3460,8 +3462,9 @@ body.blog {
     }
 
     #deck {
-        margin-left: 2.5vw;
-        margin-right: 2.5vw;
+        margin-left: var(--pad4);
+        margin-right: var(--pad4);
+        gap: var(--pad3);
     }
 
     .chatText {

--- a/index.html
+++ b/index.html
@@ -49,20 +49,6 @@
 
 		<section id="stage">
 		<div id="djStage">
-			<div id="ft-eq" aria-hidden="true">
-				<div class="ft-eq-bar"></div>
-				<div class="ft-eq-bar"></div>
-				<div class="ft-eq-bar"></div>
-				<div class="ft-eq-bar"></div>
-				<div class="ft-eq-bar"></div>
-				<div class="ft-eq-bar"></div>
-				<div class="ft-eq-bar"></div>
-				<div class="ft-eq-bar"></div>
-				<div class="ft-eq-bar"></div>
-				<div class="ft-eq-bar"></div>
-				<div class="ft-eq-bar"></div>
-				<div class="ft-eq-bar"></div>
-			</div>
 			<div id="screenBox">
 				<div id="playerArea"></div>
 				<div id="scScreen"></div>

--- a/index.html
+++ b/index.html
@@ -179,8 +179,8 @@
 						<div class="ft-avatar"></div>
 						<div class="chatContent">
 							<div class="chatHead">
-								<span class="material-symbols-outlined utitle"></span>
 								<div class="chatName"></div>
+								<span class="material-symbols-outlined utitle"></span>
 							</div>
 							<div id="chattxtKEY" class="chatText"></div>
 						</div>

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
 	<title>firetable</title>
 	<meta name="description" content="Collaborative radio." />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+	<meta name="theme-color" content="#181818" />
 	<link rel="shortcut icon" href="favicon.png" />
 	<link rel="stylesheet" href="css/reset.css" type="text/css" />
 	<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700" type="text/css" />

--- a/index.html
+++ b/index.html
@@ -631,6 +631,7 @@
 		<div id="ft-user-tip-arrow"></div>
 		<div class="utt-facts"></div>
 		<p>click user to @ them in chat</p>
+		<div class="utt-actions"></div>
 	</div>
 
 	<iframe allow="autoplay; encrypted-media" id="sc-widget" width="100%" height="166" scrolling="no" frameborder="no"

--- a/index.html
+++ b/index.html
@@ -182,6 +182,7 @@
 				<form id="newchatForm" autocomplete="off" onsubmit="return false;">
 					<input maxlength="240" autocomplete="off" name="newchat" placeholder="Chat a thing" type="text"
 						id="newchat" tabindex="0" />
+					<div id="typing-indicator"></div>
 				</form>
 				<div id="emojiPicker">
 					<div id="pickerNav"></div>
@@ -524,6 +525,10 @@
 					<div class="settingline">
 						<input type="checkbox" id="desktopNotifyMentionsToggle" name="DTNMToggle">
 						<label for="desktopNotifyMentionsToggle">Desktop notifications for @mentions</label>
+					</div>
+					<div class="settingline">
+						<input type="checkbox" id="shareTypingToggle" name="shareTypingToggle">
+						<label for="shareTypingToggle">Let others know when I'm typing</label>
 					</div>
 					<div class="settingline">
 						<input type="checkbox" id="showImagesToggle" name="showImagesToggle">

--- a/index.html
+++ b/index.html
@@ -216,15 +216,12 @@
 					<div id="userKEY" class="prson">
 						<!-- template for users -->
 						<div class="ft-avatar">
-							<span class="material-symbols-outlined blockon">block</span>
-							<span class="material-symbols-outlined imptcon">radio</span>
-							<span class="material-symbols-outlined prsnStatus">lens</span>
+							<span class="material-symbols-outlined blockon"></span>
 						</div>
+						<span class="material-symbols-outlined prsnRole">person</span>
 						<div class="prsnNameRole">
 							<span class="prsnName"></span>
-							<span class="material-symbols-outlined prsnRole"></span>
 						</div>
-						<span class="djOrder"></span>
 					</div>
 					<div id="usersDJs"></div>
 					<div id="usersBot"></div>
@@ -630,6 +627,11 @@
 	</div>
 
 	<div id="ft-tooltip" role="tooltip" aria-hidden="true"></div>
+	<div id="ft-user-tip" role="tooltip" aria-hidden="true" data-for="">
+		<div id="ft-user-tip-arrow"></div>
+		<div class="utt-facts"></div>
+		<p>click user to @ them in chat</p>
+	</div>
 
 	<iframe allow="autoplay; encrypted-media" id="sc-widget" width="100%" height="166" scrolling="no" frameborder="no"
 		src="https://w.soundcloud.com/player/?url=http%3A%2F%2Fapi.soundcloud.com%2Ftracks%2F1848notarealidthanks538&show_artwork=false"></iframe>

--- a/index.html
+++ b/index.html
@@ -383,7 +383,10 @@
 							<button id="pv0" class="material-symbols-outlined previewicon">&#xE037;</button>
 						</div>
 						<div class="qtxt">
-							<div class="listwords"><a target="_blank" href="" class="histlink"></a></div>
+							<div class="listwords">
+								<a target="_blank" href="" class="histlink"></a>
+								<button class="histeal butt graybutt material-symbols-outlined" id="apvX0">&#xE03B;</button>
+							</div>
 							<div class="fresh-meta">
 								<span class="fresh-dj-avatar ft-avatar"></span>
 								<span class="histdj"></span>

--- a/index.html
+++ b/index.html
@@ -383,7 +383,12 @@
 						</div>
 						<div class="qtxt">
 							<div class="listwords"><a target="_blank" href="" class="histlink"></a></div>
-							<span class="histdj"></span> · <span class="histdate"></span> <span class="histtime"></span>
+							<div class="fresh-meta">
+								<span class="fresh-dj-avatar ft-avatar"></span>
+								<span class="histdj"></span>
+								<span class="histdate"></span>
+								<span class="histtime"></span>
+							</div>
 						</div>
 					</div>
 				</div>

--- a/index.html
+++ b/index.html
@@ -481,6 +481,11 @@
 			</div>
 		</div>
 
+		<div class="modalThing" id="cardViewLargerModal">
+			<button role="button" class="butt graybutt iconbutt closeModal" id="cardViewLargerClose" aria-label="Close"><i class="material-symbols-outlined">close</i></button>
+			<canvas id="cardViewLargerCanvas" width="225" height="300"></canvas>
+		</div>
+
 		<div class="modalThing" id="accountSettingsBox">
 			<div class="tabs" id="accountSettingsTabs">
 				<button class="tab on" data-tab="profile-tab">Profile</button>

--- a/js/cards.js
+++ b/js/cards.js
@@ -10,6 +10,76 @@
 
 firetable.actions = firetable.actions || {};
 
+$(document)
+  .off('click.cardStatsToggle')
+  .on('click.cardStatsToggle', '#cardStats .hist-day-header', function () {
+    var $group = $(this).closest('.hist-day-group');
+    $group.toggleClass('collapsed');
+    $(this).attr('aria-expanded', String(!$group.hasClass('collapsed')));
+  });
+
+/**
+ * Build a stats panel for the current card collection.
+ * @param {Object} data - Card collection keyed by card ID
+ * @returns {string} HTML for the stats panel
+ */
+firetable.actions.renderCardStats = function (data) {
+  var keys = Object.keys(data || {});
+  var total = keys.length;
+  var minTemp = null;
+  var maxTemp = null;
+  var perDj = {};
+
+  function escapeHtml(str) {
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  keys.forEach(function (key) {
+    var card = data[key] || {};
+    var dj = (card.djname || 'Unknown DJ').trim() || 'Unknown DJ';
+    var temp = Number(card.temp);
+
+    perDj[dj] = (perDj[dj] || 0) + 1;
+
+    if (!isNaN(temp)) {
+      if (minTemp === null || temp < minTemp) minTemp = temp;
+      if (maxTemp === null || temp > maxTemp) maxTemp = temp;
+    }
+  });
+
+  var djRows = Object.keys(perDj).sort(function (a, b) {
+    if (perDj[b] !== perDj[a]) return perDj[b] - perDj[a];
+    return a.localeCompare(b);
+  }).map(function (name) {
+    return (
+      '<span class="cardStatDjRow">' +
+      '<span class="cardStatDjName">' + escapeHtml(name) + '</span>' +
+      '<span class="cardStatDjCount">' + perDj[name] + '</span>' +
+      '</span>'
+    );
+  }).join('');
+
+  return (
+    '<section id="cardStats">' +
+    '<div class="cardStatsSummary">' +
+    '<div class="cardStatTile"><span class="cardStatLabel">Total Cards</span><span class="cardStatValue">' + total + '</span></div>' +
+    '<div class="cardStatTile"><span class="cardStatLabel">Unique DJs</span><span class="cardStatValue">' + Object.keys(perDj).length + '</span></div>' +
+    '<div class="cardStatTile"><span class="cardStatLabel">Lowest Temp</span><span class="cardStatValue">' + (minTemp === null ? '--' : (minTemp + '°')) + '</span></div>' +
+    '<div class="cardStatTile"><span class="cardStatLabel">Highest Temp</span><span class="cardStatValue">' + (maxTemp === null ? '--' : (maxTemp + '°')) + '</span></div>' +
+    '</div>' +
+    '<div class="cardStatDjBreakdown hist-day-group collapsed">' +
+    '<div class="hist-day-header" role="button" aria-expanded="false">Cards Per DJ</div>' +
+    '<div class="hist-day-items cardStatDjList">' + djRows + '</div>' +
+    '</div>' +
+    '</section>'
+  );
+};
+
 /**
  * Open the card case modal and render all cards the user owns.
  */
@@ -22,6 +92,7 @@ firetable.actions.cardCase = function () {
       twemoji.parse($("#cardsMain")[0]);
       return;
     }
+    $("#cardsMain").append(firetable.actions.renderCardStats(data));
     for (var key in data) {
       if (!data.hasOwnProperty(key)) continue;
       var childData = data[key];
@@ -31,6 +102,7 @@ firetable.actions.cardCase = function () {
         '<canvas width="225" height="300" class="caseCard" id="cardMaker' + key + '"></canvas>' +
         '<span role="button" onclick="firetable.actions.giftCard(\'' + key + '\')" class="cardGiftChat">Gift to DJ</span>' +
         '<span role="button" onclick="firetable.actions.chatCard(\'' + key + '\')" class="cardShareChat">Share In Chat</span>' +
+        '<span role="button" onclick="firetable.actions.viewLargerCard(\'' + key + '\')" class="cardViewLarger">View Larger</span>' +
         '</span>'
       );
       firetable.actions.displayCard(childData, key);
@@ -44,6 +116,24 @@ firetable.actions.cardCase = function () {
  */
 firetable.actions.chatCard = function (cardid) {
   ftapi.actions.sendChat("Check out my card...", cardid);
+};
+
+/**
+ * Open a near-fullscreen modal showing just the card canvas.
+ * @param {string} cardid - Card key
+ */
+firetable.actions.viewLargerCard = function (cardid) {
+  var $src = $('#cardMaker' + cardid);
+  if (!$src.length) return;
+  // Clone the canvas and draw the source into it at native resolution
+  var srcCanvas = $src[0];
+  var $dest = $('#cardViewLargerCanvas');
+  var dest = $dest[0];
+  dest.width  = srcCanvas.width;
+  dest.height = srcCanvas.height;
+  dest.getContext('2d').drawImage(srcCanvas, 0, 0);
+  $('#overlay').addClass('show');
+  $('#cardViewLargerModal').addClass('show');
 };
 
 /**

--- a/js/chat.js
+++ b/js/chat.js
@@ -369,17 +369,22 @@ firetable.ui.setupChatEvents = function () {
   });
 
   // ── Typing indicator ──
+  // State lives at typing/{uid} (top-level node, not inside users/):
+  //   value = username string → user is sharing their name
+  //   value = true           → user is typing anonymously
+  //   absent / null          → not typing
+  // This keeps the listener tiny (just the typing node) and rules simple.
   var _typingRef = null;
   var _typingTimeout = null;
   var _typingListener = null;
-  var _typingUsers = {}; // uid -> username
+  var _typingUsers = {}; // uid -> string (name) | true (anonymous)
 
   function _renderTypingIndicator() {
     var named = [];
     var anonymousCount = 0;
     for (var uid in _typingUsers) {
       if (!_typingUsers.hasOwnProperty(uid) || uid === ftapi.uid) continue;
-      if (_typingUsers[uid] === null) {
+      if (_typingUsers[uid] === true) {
         anonymousCount++;
       } else {
         named.push(_typingUsers[uid]);
@@ -406,23 +411,23 @@ firetable.ui.setupChatEvents = function () {
 
   function _setTyping(isTyping) {
     if (!_typingRef || !ftapi.uid) return;
-    _typingRef.set(isTyping ? true : null);
-  }
-
-  function _setShareTyping(share) {
-    if (!ftapi.uid) return;
-    firebase.app("firetable").database().ref("users/" + ftapi.uid + "/shareTyping").set(share ? null : false);
+    if (isTyping) {
+      // Write name if sharing, otherwise boolean true (anonymous)
+      var val = (firetable.shareTyping !== false && ftapi.uname) ? ftapi.uname : true;
+      _typingRef.set(val);
+    } else {
+      _typingRef.set(null);
+    }
   }
 
   function _startTypingListener() {
     if (_typingListener) return;
-    var usersRef = firebase.app("firetable").database().ref("users");
-    _typingListener = usersRef.on("value", function (snap) {
+    var typingRef = firebase.app("firetable").database().ref("typing");
+    _typingListener = typingRef.on("value", function (snap) {
       _typingUsers = {};
       snap.forEach(function (child) {
-        var d = child.val();
-        if (d && d.typing && child.key !== ftapi.uid) {
-          _typingUsers[child.key] = (d.shareTyping === false) ? null : (d.username || child.key);
+        if (child.key !== ftapi.uid && child.val() !== null) {
+          _typingUsers[child.key] = child.val(); // string or true
         }
       });
       _renderTypingIndicator();
@@ -430,9 +435,8 @@ firetable.ui.setupChatEvents = function () {
   }
 
   ftapi.events.on("loggedIn", function () {
-    _typingRef = firebase.app("firetable").database().ref("users/" + ftapi.uid + "/typing");
+    _typingRef = firebase.app("firetable").database().ref("typing/" + ftapi.uid);
     _typingRef.onDisconnect().set(null);
-    _setShareTyping(firetable.shareTyping !== false);
     _startTypingListener();
   });
 

--- a/js/chat.js
+++ b/js/chat.js
@@ -368,6 +368,87 @@ firetable.ui.setupChatEvents = function () {
     $(this).closest('.chatText').toggleClass('hideImg');
   });
 
+  // ── Typing indicator ──
+  var _typingRef = null;
+  var _typingTimeout = null;
+  var _typingListener = null;
+  var _typingUsers = {}; // uid -> username
+
+  function _renderTypingIndicator() {
+    var named = [];
+    var anonymousCount = 0;
+    for (var uid in _typingUsers) {
+      if (!_typingUsers.hasOwnProperty(uid) || uid === ftapi.uid) continue;
+      if (_typingUsers[uid] === null) {
+        anonymousCount++;
+      } else {
+        named.push(_typingUsers[uid]);
+      }
+    }
+    var $el = $('#typing-indicator');
+    var total = named.length + anonymousCount;
+    if (!total) { $el.empty(); return; }
+
+    var label;
+    if (anonymousCount && !named.length) {
+      label = anonymousCount === 1 ? 'Someone is typing' : anonymousCount + ' people are typing';
+    } else if (!anonymousCount) {
+      label = named.length === 1
+        ? named[0] + ' is typing'
+        : named.length === 2
+          ? named[0] + ' and ' + named[1] + ' are typing'
+          : total + ' people are typing';
+    } else {
+      label = total + ' people are typing';
+    }
+    $el.html('<div class="typing-dots"><span></span><span></span><span></span></div><span>' + label + '</span>');
+  }
+
+  function _setTyping(isTyping) {
+    if (!_typingRef || !ftapi.uid) return;
+    _typingRef.set(isTyping ? true : null);
+  }
+
+  function _setShareTyping(share) {
+    if (!ftapi.uid) return;
+    firebase.app("firetable").database().ref("users/" + ftapi.uid + "/shareTyping").set(share ? null : false);
+  }
+
+  function _startTypingListener() {
+    if (_typingListener) return;
+    var usersRef = firebase.app("firetable").database().ref("users");
+    _typingListener = usersRef.on("value", function (snap) {
+      _typingUsers = {};
+      snap.forEach(function (child) {
+        var d = child.val();
+        if (d && d.typing && child.key !== ftapi.uid) {
+          _typingUsers[child.key] = (d.shareTyping === false) ? null : (d.username || child.key);
+        }
+      });
+      _renderTypingIndicator();
+    });
+  }
+
+  ftapi.events.on("loggedIn", function () {
+    _typingRef = firebase.app("firetable").database().ref("users/" + ftapi.uid + "/typing");
+    _typingRef.onDisconnect().set(null);
+    _setShareTyping(firetable.shareTyping !== false);
+    _startTypingListener();
+  });
+
+  ftapi.events.on("loggedOut", function () {
+    _typingUsers = {};
+    _renderTypingIndicator();
+    _typingRef = null;
+    clearTimeout(_typingTimeout);
+  });
+
+  $("#newchat").on("input", function () {
+    _setTyping(true);
+    clearTimeout(_typingTimeout);
+    _typingTimeout = setTimeout(function () { _setTyping(null); }, 4000);
+  });
+
   // ── Chat Input: Send Message + Slash Commands ──
   $("#newchat").bind("keypress", function (e) {
     if (e.key === "Enter") {
@@ -437,6 +518,8 @@ firetable.ui.setupChatEvents = function () {
         ftapi.actions.sendChat(txt);
       }
 
+      clearTimeout(_typingTimeout);
+      _setTyping(null);
       $("#newchat").val("");
       $("#emojiPicker").slideUp();
       $("#pickEmoji").removeClass("on");

--- a/js/chat.js
+++ b/js/chat.js
@@ -69,10 +69,17 @@ firetable.actions.processFireReactionMessage = function (chatData) {
   }
 
   if (isRain) {
-    firetable.fireReactors = {};
-    firetable.fireCount = 0;
-    firetable.actions.updateFireReactionDisplay();
-    $("#cloud_with_rain").addClass("on");
+    if (firetable.fireReactors[chatData.id]) {
+      delete firetable.fireReactors[chatData.id];
+      firetable.fireCount = Math.max(0, firetable.fireCount - 1);
+      firetable.actions.updateFireReactionDisplay();
+    } else {
+      firetable.actions.syncFireReactionButtons();
+    }
+    if (chatData.id === ftapi.uid) {
+      $("#cloud_with_rain").addClass("on");
+      $("#fire").removeClass("on");
+    }
     return true;
   }
 
@@ -520,7 +527,9 @@ firetable.ui.setupChatEvents = function () {
   // ── Fire / Rain reaction buttons ──
   $("#fire").bind("click", function () {
     if (ftapi.uid && firetable.fireReactors[ftapi.uid]) {
-      ftapi.actions.sendChat(":fire_off:");
+      ftapi.actions.sendChat(":cloud_with_rain:");
+      $("#cloud_with_rain").addClass("on");
+      $("#fire").removeClass("on");
     } else {
       ftapi.actions.sendChat(":fire:");
     }

--- a/js/chat.js
+++ b/js/chat.js
@@ -337,6 +337,18 @@ firetable.ui.setupChatEvents = function () {
     if (atBottom || ftapi.uid === chatData.id) {
       firetable.utilities.scrollToBottom();
     }
+
+    // ── Chat pruning: remove oldest messages to prevent unbounded DOM growth ──
+    // Canvases (card shares), avatar background-images, and twemoji nodes all
+    // hold memory that never gets freed without this.
+    var MAX_CHAT_MESSAGES = 200;
+    var $allChats = $('#chats').children();
+    if ($allChats.length > MAX_CHAT_MESSAGES) {
+      $allChats.slice(0, $allChats.length - MAX_CHAT_MESSAGES).remove();
+      // Invalidate grouping state so the next message always starts a fresh block
+      firetable.lastChatPerson = false;
+      firetable.lastChatId = false;
+    }
   });
 
   // ── Chat Removal (mod delete) ──

--- a/js/constants.js
+++ b/js/constants.js
@@ -41,7 +41,8 @@ var STORAGE = {
   lastfmSession:      "ftLastfmSession",
   navView:            "firetableNavView",
   navSide:            "firetableNavSide",
-  navMobile:          "firetableNavMobile"
+  navMobile:          "firetableNavMobile",
+  shareTyping:        "firetableShareTyping"
 };
 
 // ─── External Service URLs ──────────────────────────────────────────────────

--- a/js/constants.js
+++ b/js/constants.js
@@ -49,7 +49,7 @@ var SC_RESOLVE_URL = "https://thompsn.com/resolvesc/";
 /** SoundCloud general proxy */
 var SC_PROXY_URL = "https://thompsn.com/soundcloud/";
 /** SoundCloud API track base URL */
-var SC_API_TRACK_URL = "http://api.soundcloud.com/tracks/";
+var SC_API_TRACK_URL = "https://api.soundcloud.com/tracks/";
 /** Last.fm API base URL */
 var LASTFM_API_URL = "https://ws.audioscrobbler.com/2.0/";
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -38,7 +38,10 @@ var STORAGE = {
   desktopNotify:      "firetableDTNM",
   screenControl:      "firetableScreenControl",
   avatarStyle:        "firetableAvatarStyle",
-  lastfmSession:      "ftLastfmSession"
+  lastfmSession:      "ftLastfmSession",
+  navView:            "firetableNavView",
+  navSide:            "firetableNavSide",
+  navMobile:          "firetableNavMobile"
 };
 
 // ─── External Service URLs ──────────────────────────────────────────────────

--- a/js/fire.js
+++ b/js/fire.js
@@ -29,9 +29,21 @@ class Ember
 		})
 		
 		
-		setInterval(() => {
-			this.addEmber();
-		}, 300)
+		this._intervalId = null;
+		this.resume();
+	}
+
+	pause() {
+		if (this._intervalId) {
+			clearInterval(this._intervalId);
+			this._intervalId = null;
+		}
+	}
+
+	resume() {
+		if (!this._intervalId) {
+			this._intervalId = setInterval(() => { this.addEmber(); }, 300);
+		}
 	}
 	
 	stoke(multiplier)
@@ -142,10 +154,21 @@ class Fire
 			this.flame.filters.push(new PIXI.filters.PixelateFilter());
 		}
 		
-		setInterval(() => {
-			this.addFlame();
-		}, 50)
-		
+		this._intervalId = null;
+		this.resume();
+	}
+
+	pause() {
+		if (this._intervalId) {
+			clearInterval(this._intervalId);
+			this._intervalId = null;
+		}
+	}
+
+	resume() {
+		if (!this._intervalId) {
+			this._intervalId = setInterval(() => { this.addFlame(); }, 50);
+		}
 	}
 	
 	makeBlob(texture)
@@ -334,6 +357,16 @@ class Stage
 			var alpha = visible ? ((0.08 + (normalized * 0.62) + (overdriveNorm * 0.28)) * layerWeight * this.flames[i].coreBoost) : 0;
 			this.flames[i].fire.alpha = Math.min(alpha, 1);
 			this.flames[i].flame.alpha = visible ? Math.min(1, 0.88 + (overdriveNorm * 0.18)) : 0;
+		}
+
+		// Pause/resume animation intervals to avoid burning CPU/GPU when fire
+		// is not visible (no one is DJing).
+		if (visible) {
+			for (var j = 0; j < this.flames.length; j++) { this.flames[j].resume(); }
+			this.ember.resume();
+		} else {
+			for (var j = 0; j < this.flames.length; j++) { this.flames[j].pause(); }
+			this.ember.pause();
 		}
 	}
 

--- a/js/firetable.js
+++ b/js/firetable.js
@@ -452,7 +452,7 @@ ftapi.actions = {
     newlist.set(obj);
     return listid;
   },
-  addToList: function(type, name, cid, dest, callback) {
+  addToList: function(type, name, cid, dest, callback, img) {
     var destref;
     if (dest) {
       if (dest == 0) {
@@ -468,6 +468,7 @@ ftapi.actions = {
       name: name,
       cid: cid
     };
+    if (img) info.img = img;
     var newTrack = destref.push(info, function() {
       if (callback) callback();
     });

--- a/js/helpers.js
+++ b/js/helpers.js
@@ -9,6 +9,20 @@
 
 firetable.utilities = {
 
+  // ─── Volume ───────────────────────────────────────────────────────────────
+
+  /**
+   * Return the effective playback volume, respecting mute state.
+   * Avoids the `parseInt("0") || DEFAULT_VOLUME` bug that causes loud bursts.
+   * @returns {number} 0 when muted, otherwise the stored volume (or DEFAULT_VOLUME).
+   */
+  getEffectiveVolume: function () {
+    var muted = localStorage[STORAGE.mute];
+    if (muted && muted !== "false") return 0;
+    var vol = parseInt(localStorage[STORAGE.volume], 10);
+    return isNaN(vol) ? DEFAULT_VOLUME : vol;
+  },
+
   // ─── Avatar URL ──────────────────────────────────────────────────────────
 
   /**
@@ -391,15 +405,13 @@ firetable.utilities = {
 
     var secSince = Math.floor(timeSince / 1000);
 
+    var vol = firetable.utilities.getEffectiveVolume();
+
     if (data.type === MEDIA_YOUTUBE) {
       if (firetable.scLoaded) firetable.scwidget.pause();
+      player.setVolume(vol);
       if (!firetable.disableMediaPlayback) {
         player.loadVideoById(data.cid, secSince, "large");
-      }
-      if (opts.forceVolume) {
-        var vol = $("#slider").slider("value");
-        player.setVolume(vol);
-        firetable.scwidget.setVolume(vol);
       }
     } else if (data.type === MEDIA_SOUNDCLOUD) {
       if (firetable.ytLoaded) player.stopVideo();
@@ -408,14 +420,10 @@ firetable.utilities = {
         firetable.scwidget.load(SC_API_TRACK_URL + data.cid, {
           auto_play: true,
           callback: function () {
+            firetable.scwidget.setVolume(vol);
             firetable.scwidget.play();
           }
         });
-      }
-      if (opts.forceVolume) {
-        var vol = $("#slider").slider("value");
-        player.setVolume(vol);
-        firetable.scwidget.setVolume(vol);
       }
     }
   }

--- a/js/init.js
+++ b/js/init.js
@@ -99,11 +99,7 @@ firetable.init = function () {
   firetable.scwidget.bind(SC.Widget.Events.READY, function () {
     // When a SC track starts playing, apply volume + seek
     firetable.scwidget.bind(SC.Widget.Events.PLAY, function () {
-      var vol = parseInt(localStorage[STORAGE.volume], 10);
-      if (isNaN(vol)) {
-        vol = DEFAULT_VOLUME;
-        localStorage[STORAGE.volume] = DEFAULT_VOLUME;
-      }
+      var vol = firetable.utilities.getEffectiveVolume();
       firetable.scwidget.setVolume(vol);
       if (firetable.scSeek) firetable.scwidget.seekTo(firetable.scSeek);
     });
@@ -116,7 +112,10 @@ firetable.init = function () {
       if (!firetable.preview) {
         firetable.scSeek = timeSince;
         if (!firetable.disableMediaPlayback) {
-          firetable.scwidget.load(SC_API_TRACK_URL + data.cid, { auto_play: true });
+          firetable.scwidget.load(SC_API_TRACK_URL + data.cid, {
+            auto_play: true,
+            callback: function () { firetable.scwidget.play(); }
+          });
         }
       }
     }
@@ -172,6 +171,27 @@ firetable.init = function () {
   /** Current user was un-banned */
   ftapi.events.on("userUnbanned", function () {
     window.location.reload();
+  });
+
+  // ── Visibility-change recovery ─────────────────────────────────────────
+  // Chrome suppresses audible autoplay in background tabs.  When the user
+  // returns, retry playback so they don't have to click "refresh audio".
+  document.addEventListener('visibilitychange', function () {
+    if (document.hidden || firetable.disableMediaPlayback) return;
+    var vol = firetable.utilities.getEffectiveVolume();
+    if (firetable.song && firetable.song.type == MEDIA_YOUTUBE && firetable.ytLoaded) {
+      if (player.getPlayerState() !== 1) {
+        player.setVolume(vol);
+        player.playVideo();
+      }
+    } else if (firetable.song && firetable.song.type == MEDIA_SOUNDCLOUD && firetable.scLoaded) {
+      firetable.scwidget.isPaused(function (paused) {
+        if (paused) {
+          firetable.scwidget.setVolume(vol);
+          firetable.scwidget.play();
+        }
+      });
+    }
   });
 
   // ── UI Init (wires everything up) ──

--- a/js/player.js
+++ b/js/player.js
@@ -48,11 +48,7 @@ function onPlayerReady(event) {
   firetable.ytLoaded = true;
 
   // ── Restore volume ──
-  var vol = parseInt(localStorage[STORAGE.volume], 10);
-  if (isNaN(vol)) {
-    vol = DEFAULT_VOLUME;
-    localStorage[STORAGE.volume] = DEFAULT_VOLUME;
-  }
+  var vol = firetable.utilities.getEffectiveVolume();
   player.setVolume(vol);
 
   // ── Restore mute state ──
@@ -68,12 +64,14 @@ function onPlayerReady(event) {
   }
 
   // ── Volume slider ──
+  var sliderVol = parseInt(localStorage[STORAGE.volume], 10);
+  if (isNaN(sliderVol)) sliderVol = DEFAULT_VOLUME;
   $("#slider").slider({
     orientation: "vertical",
     range: "min",
     min: 0,
     max: 100,
-    value: vol,
+    value: sliderVol,
     step: 5,
     slide: function (event, ui) {
       player.setVolume(ui.value);

--- a/js/playlist.js
+++ b/js/playlist.js
@@ -424,9 +424,9 @@ firetable.ui.setupPlaylistEvents = function () {
             .attr("data-cid", thisone.cid);
 
       // Album art thumbnail
-      var artUrl = thisone.type === MEDIA_YOUTUBE
+      var artUrl = (thisone.type == MEDIA_YOUTUBE)
         ? 'https://i.ytimg.com/vi/' + thisone.cid + '/mqdefault.jpg'
-        : '';
+        : (thisone.img || (firetable.imgCache && firetable.imgCache[thisone.cid]) || '');
       if (artUrl) $newli.find('.q-art').css('background-image', 'url(' + artUrl + ')');
 
       // Preview button

--- a/js/room.js
+++ b/js/room.js
@@ -142,8 +142,14 @@ function renderHistoryItem(data, $template, containerSel, artClass) {
   $histItem.find('.histeal').attr('id', "apv" + data.type + data.cid).on('click', function () {
     var $btn = $(this);
     var btnCid = $(this).closest('.pvbar').attr('data-cid');
-    var btnType = $(this).closest('.pvbar').attr('data-type');
-    var btnTitle = firetable.utilities.htmlEscape($(this).closest('.pvbar').find('.histlink').text());
+    var btnType = parseInt($(this).closest('.pvbar').attr('data-type'), 10);
+    var btnImg = $(this).closest('.pvbar').attr('data-img') || '';
+    var $histlink = $(this).closest('.pvbar').find('.histlink');
+    var $trackTitle = $histlink.find('.fresh-track-title');
+    var $trackArtist = $histlink.find('.fresh-track-artist');
+    var btnTitle = ($trackTitle.length && $trackArtist.length)
+      ? firetable.utilities.htmlEscape($trackArtist.text().trim() + ' - ' + $trackTitle.text().trim())
+      : firetable.utilities.htmlEscape($histlink.text());
 
     // If this button's picker is already open, close it
     if (firetable.stealSourceBtn && firetable.stealSourceBtn.is($btn) && !$("#stealContain").is(':hidden')) {
@@ -171,7 +177,7 @@ function renderHistoryItem(data, $template, containerSel, artClass) {
       $("#grab").removeClass('on');
 
       firetable.stealSourceBtn = $btn;
-      firetable.stealTarget = { cid: btnCid, type: btnType, title: btnTitle };
+      firetable.stealTarget = { cid: btnCid, type: btnType, title: btnTitle, img: btnImg };
       $btn.addClass('on');
 
       var stealContainEl = document.getElementById('stealContain');
@@ -185,6 +191,12 @@ function renderHistoryItem(data, $template, containerSel, artClass) {
   if (artClass) {
     $histItem.find('.' + artClass).css('background-image', 'url(' + data.img + ')');
   }
+  // Cache img by cid so playlist renderer can use it even without Firebase storage
+  if (data.img && data.cid) {
+    firetable.imgCache = firetable.imgCache || {};
+    firetable.imgCache[data.cid] = data.img;
+  }
+  $histItem.attr('data-img', data.img || '');
 
   if (containerSel === "#thehistory") {
     var dateKey = firetable.utilities.format_date(data.when);

--- a/js/room.js
+++ b/js/room.js
@@ -90,7 +90,17 @@ function renderHistoryItem(data, $template, containerSel, artClass) {
   });
 
   // Track link
-  $histItem.find('.histlink').attr('id', data.histID).text(data.artist + " - " + data.title);
+  var titleText = firetable.ui.strip(data.title || "");
+  var artistText = firetable.ui.strip(data.artist || "");
+  var $histLink = $histItem.find('.histlink').attr('id', data.histID);
+  if (artClass === "discart") {
+    $histLink.html(
+      '<span class="fresh-track-title">' + firetable.utilities.htmlEscape(titleText) + '</span>' +
+      '<span class="fresh-track-artist">' + firetable.utilities.htmlEscape(artistText) + '</span>'
+    );
+  } else {
+    $histLink.text(artistText + " - " + titleText);
+  }
   $histItem.find('.tracklink-btn').attr('href', data.url || '');
 
   // Edit tags button (mod only)
@@ -115,9 +125,16 @@ function renderHistoryItem(data, $template, containerSel, artClass) {
 
   // Metadata
   $histItem.find('.histdj').text(data.dj);
-  $histItem.find('.hist-dj-avatar')
-    .css('background-image', 'url(' + firetable.utilities.avatarURL(data.djid || data.dj, data.dj, '40x40') + ')')
-    .attr('data-label', data.dj);
+  if (artClass === "discart") {
+    $histItem.find('.fresh-dj-avatar')
+      .css('background-image', 'url(' + firetable.utilities.avatarURL(data.djid || data.dj, data.dj, '40x40') + ')')
+      .attr('data-label', data.dj)
+      .attr('aria-label', data.dj);
+  } else {
+    $histItem.find('.hist-dj-avatar')
+      .css('background-image', 'url(' + firetable.utilities.avatarURL(data.djid || data.dj, data.dj, '40x40') + ')')
+      .attr('data-label', data.dj);
+  }
   $histItem.find('.histdate').text(firetable.utilities.format_date(data.when));
   $histItem.find('.histtime').text(firetable.utilities.format_time(data.when));
 

--- a/js/room.js
+++ b/js/room.js
@@ -644,8 +644,8 @@ firetable.ui.setupRoomEvents = function () {
             if (hasPending && !!data[key].removeAfter === !!_pendingDeparture[data[key].id]) {
               delete _pendingDeparture[data[key].id];
             }
-            var departureTitleOff = isSelfDj ? 'You will not be taking the bus after your next play' : djDisplayName + ' will not be taking the bus after their next play';
-            var departureTitleOn  = isSelfDj ? 'You are taking the bus after your next play'           : djDisplayName + ' is taking the bus after their next play';
+            var departureTitleOff = isSelfDj ? `Step down after your next play` : 'Have ' + djDisplayName + ' step down after their next play';
+            var departureTitleOn  = isSelfDj ? `Don't step down after your next play` : `Don't have ` + djDisplayName + ' step down after their next play';
             var departureTitle = removeAfterValue ? departureTitleOn : departureTitleOff;
             departureIndicator = '<button class="iconbutt deckDepartureBtn' + (removeAfterValue ? ' on' : '') + '" data-tablekey="' + key + '" data-userid="' + data[key].id + '" data-djname="' + djDisplayName + '" title="' + departureTitle + '"><i class="material-symbols-outlined">departure_board</i></button>';
           } else if (data[key].removeAfter) {

--- a/js/room.js
+++ b/js/room.js
@@ -604,6 +604,7 @@ firetable.ui.setupRoomEvents = function () {
   });
 
   // ── DJ Table ──
+  var _pendingDeparture = {}; // userId -> true|null while bot command is in-flight
   ftapi.events.on("tableChanged", function (data) {
     firetable.tableData = data;
     var html = "";
@@ -620,9 +621,26 @@ firetable.ui.setupRoomEvents = function () {
           var actionBtn = showBtn
             ? '<button class="iconbutt deckRemoveBtn" data-userid="' + data[key].id + '" data-tablekey="' + key + '" title="' + btnTitle + '"><i class="material-symbols-outlined">' + btnIcon + '</i></button>'
             : '';
-          var departureIndicator = data[key].removeAfter
-            ? '<span class="removemeIcon material-symbols-outlined" title="Stepping down after this song">departure_board</span>'
-            : '';
+          var departureIndicator;
+          if (showBtn) {
+            var isSelfDj = data[key].id === ftapi.uid;
+            var djDisplayName = firetable.utilities.htmlEscape(data[key].name);
+            // Use pending state if a bot command is in-flight, else use Firebase value
+            var hasPending = _pendingDeparture.hasOwnProperty(data[key].id);
+            var removeAfterValue = hasPending ? _pendingDeparture[data[key].id] : data[key].removeAfter;
+            // Clear pending once Firebase has caught up
+            if (hasPending && !!data[key].removeAfter === !!_pendingDeparture[data[key].id]) {
+              delete _pendingDeparture[data[key].id];
+            }
+            var departureTitleOff = isSelfDj ? 'You will not be taking the bus after your next play' : djDisplayName + ' will not be taking the bus after their next play';
+            var departureTitleOn  = isSelfDj ? 'You are taking the bus after your next play'           : djDisplayName + ' is taking the bus after their next play';
+            var departureTitle = removeAfterValue ? departureTitleOn : departureTitleOff;
+            departureIndicator = '<button class="iconbutt deckDepartureBtn' + (removeAfterValue ? ' on' : '') + '" data-tablekey="' + key + '" data-userid="' + data[key].id + '" data-djname="' + djDisplayName + '" title="' + departureTitle + '"><i class="material-symbols-outlined">departure_board</i></button>';
+          } else if (data[key].removeAfter) {
+            departureIndicator = '<span class="removemeIcon material-symbols-outlined" title="Stepping down after this song">departure_board</span>';
+          } else {
+            departureIndicator = '';
+          }
           html += '<div id="spt' + countr + '" class="spot">' +
             '<div class="avtr" id="avtr' + countr + '" style="background-image: url(' +
             firetable.utilities.avatarURL(data[key].id, data[key].name) + ');"></div>' +
@@ -651,6 +669,29 @@ firetable.ui.setupRoomEvents = function () {
     $("#deck").html(html);
     $("#deck").off('click.addme').on('click.addme', '.addmeButt', function () {
       ftapi.actions.sendBotCommand("!addme");
+    });
+    $("#deck").off('click.departure').on('click.departure', '.deckDepartureBtn', function () {
+      var $btn = $(this);
+      var tableKey = $btn.data('tablekey');
+      var userId = $btn.data('userid');
+      var djName = $btn.data('djname');
+      var isSelf = userId === ftapi.uid;
+      var isOn = $btn.hasClass('on');
+      var newIsOn = !isOn;
+      // Optimistic UI update
+      $btn.toggleClass('on', newIsOn);
+      var newTitle = newIsOn
+        ? (isSelf ? 'You are taking the bus after your next play'           : djName + ' is taking the bus after their next play')
+        : (isSelf ? 'You will not be taking the bus after your next play' : djName + ' will not be taking the bus after their next play');
+      $btn.attr('title', newTitle);
+      if (isSelf) {
+        // Record pending state so re-renders don't clobber UI while bot processes the command
+        _pendingDeparture[userId] = newIsOn ? true : null;
+        ftapi.actions.sendBotCommand(newIsOn ? '!removeafter' : '!dontremoveme');
+      } else {
+        _pendingDeparture[userId] = newIsOn ? true : null;
+        firebase.app("firetable").database().ref("table/" + tableKey + "/removeAfter").set(newIsOn ? true : null);
+      }
     });
     $("#deck").off('click.remove').on('click.remove', '.deckRemoveBtn', function () {
       var userId = $(this).data('userid');

--- a/js/room.js
+++ b/js/room.js
@@ -264,12 +264,15 @@ firetable.ui.setupRoomEvents = function () {
 
   // ── Discover (Recently Played by Others) ──
   var $discoverItem = $('#thediscovers .pvbar').remove();
+  firetable._produceCache = firetable._produceCache || [];
   ftapi.events.on('newProduce', function (data) {
+    firetable._produceCache.push(data);
     renderHistoryItem(data, $discoverItem, "#thediscovers", "discart");
   });
 
   // ── History (Your Play History) ──
   var $historyItem = $('#thehistory .pvbar').remove();
+  firetable._historyCache = firetable._historyCache || [];
 
   function applyHistoryFilter() {
     var q = ($("#histFilter").val() || "").toLowerCase().trim();
@@ -291,8 +294,28 @@ firetable.ui.setupRoomEvents = function () {
   });
 
   ftapi.events.on('newHistory', function (data) {
+    firetable._historyCache.push(data);
     renderHistoryItem(data, $historyItem, "#thehistory", "histart");
     applyHistoryFilter();
+  });
+
+  // ── Re-render history/discover after re-login ──
+  // Firebase won't re-fire child_added for already-seen items after a logout/login
+  // cycle, so replay from cache into the now-reattached containers.
+  ftapi.events.on('loggedIn', function () {
+    if (firetable._produceCache && firetable._produceCache.length) {
+      $('#thediscovers').empty();
+      firetable._produceCache.forEach(function (data) {
+        renderHistoryItem(data, $discoverItem, "#thediscovers", "discart");
+      });
+    }
+    if (firetable._historyCache && firetable._historyCache.length) {
+      $('#thehistory').empty();
+      firetable._historyCache.forEach(function (data) {
+        renderHistoryItem(data, $historyItem, "#thehistory", "histart");
+      });
+      applyHistoryFilter();
+    }
   });
 
   // ── Edited History (tag correction) ──

--- a/js/room.js
+++ b/js/room.js
@@ -733,16 +733,13 @@ firetable.ui.setupRoomEvents = function () {
       if (userId === ftapi.uid) {
         ftapi.actions.sendBotCommand("!removeme");
       } else {
-        var tableKey = $(this).data('tablekey');
-        firebase.app("firetable").database().ref("table/" + tableKey).remove();
-        if (firetable.waitlistData) {
-          for (var wkey in firetable.waitlistData) {
-            if (firetable.waitlistData.hasOwnProperty(wkey) && firetable.waitlistData[wkey].id === userId) {
-              firebase.app("firetable").database().ref("waitlist/" + wkey).remove();
-              break;
-            }
+        var djName = firetable.tableData && (function () {
+          for (var k in firetable.tableData) {
+            if (firetable.tableData.hasOwnProperty(k) && firetable.tableData[k].id === userId)
+              return firetable.tableData[k].name;
           }
-        }
+        })();
+        if (djName) ftapi.actions.sendBotCommand("!remove " + djName);
       }
     });
 

--- a/js/room.js
+++ b/js/room.js
@@ -423,10 +423,10 @@ firetable.ui.setupRoomEvents = function () {
 
       if (firetable.ytLoaded && !firetable.preview) {
         if (firetable.scLoaded) firetable.scwidget.pause();
-        if (!firetable.disableMediaPlayback) player.loadVideoById(data.cid, secSince, "large");
-        var thevol = $("#slider").slider("value");
+        var thevol = firetable.utilities.getEffectiveVolume();
         player.setVolume(thevol);
         firetable.scwidget.setVolume(thevol);
+        if (!firetable.disableMediaPlayback) player.loadVideoById(data.cid, secSince, "large");
       }
 
     } else if (data.type === MEDIA_SOUNDCLOUD) {
@@ -448,7 +448,7 @@ firetable.ui.setupRoomEvents = function () {
             auto_play: true,
             single_active: false,
             callback: function () {
-              var vol = parseInt(localStorage[STORAGE.volume], 10) || DEFAULT_VOLUME;
+              var vol = firetable.utilities.getEffectiveVolume();
               player.setVolume(vol);
               firetable.scwidget.setVolume(vol);
               // Explicitly play — auto_play can be suppressed in background tabs

--- a/js/ui.js
+++ b/js/ui.js
@@ -890,9 +890,8 @@ firetable.ui.setupMiscEvents = function () {
   $('#shareTypingToggle').change(function () {
     localStorage[STORAGE.shareTyping] = this.checked;
     firetable.shareTyping = this.checked;
-    if (ftapi.uid) {
-      firebase.app("firetable").database().ref("users/" + ftapi.uid + "/shareTyping").set(this.checked ? null : false);
-    }
+    // No Firebase write needed — preference is encoded in the value written
+    // to typing/{uid} on the next keypress (username vs true).
   });
   $('#showImagesToggle').change(function () {
     firetable.debug && console.log("show images " + (this.checked ? "on" : "off"));

--- a/js/ui.js
+++ b/js/ui.js
@@ -582,7 +582,8 @@ firetable.ui.setupMiscEvents = function () {
     var src = firetable.stealTarget || (firetable.song && firetable.song.cid != 0 && {
       cid: firetable.song.cid,
       type: firetable.song.type,
-      title: firetable.song.artist + " - " + firetable.song.title
+      title: firetable.song.artist + " - " + firetable.song.title,
+      img: (firetable.imgCache && firetable.imgCache[firetable.song.cid]) || ''
     });
     if (src) {
       if (firetable.stealSourceBtn) {
@@ -592,7 +593,7 @@ firetable.ui.setupMiscEvents = function () {
         $("#grab").removeClass('on');
       }
       firetable.stealTarget = null;
-      ftapi.actions.addToList(src.type, src.title, src.cid, dest);
+      ftapi.actions.addToList(src.type, src.title, src.cid, dest, null, src.img);
       $("#stealContain").hide();
     }
   });

--- a/js/ui.js
+++ b/js/ui.js
@@ -506,7 +506,7 @@ firetable.ui.tooltip = (function () {
       hide();
     });
 
-    // ── User list: title-based tooltips ──
+    // ── User list: title-based tooltips (for blocked icon etc.) ──
     $('#allUsersWrap').on('mouseenter.ft-tooltip', '[title]', function () {
       var $el = $(this), text = $el.attr('title');
       $el.attr('data-ft-title', text).removeAttr('title');
@@ -516,6 +516,118 @@ firetable.ui.tooltip = (function () {
       $el.attr('title', $el.attr('data-ft-title')).removeAttr('data-ft-title');
       hide();
     });
+
+    // ── User list: rich user info tooltip on .prson hover ──
+    var userTipEl = document.getElementById('ft-user-tip');
+    var userTipArrowEl = document.getElementById('ft-user-tip-arrow');
+    var $userTip  = $(userTipEl);
+    var _cardCountCache = {};
+
+    function showUserTip(anchorEl, userid) {
+      var userData = ftapi.users && ftapi.users[userid];
+      if (!userData) return;
+
+      var role = userData.hostbot  ? 'Bot'
+               : userData.supermod ? 'Supermod'
+               : userData.mod      ? 'Mod'
+               : 'Member';
+
+      var facts = [];
+
+      if (userData.joined) {
+        facts.push({ label: 'Joined', val: firetable.utilities.format_date(userData.joined) });
+      }
+
+      facts.push({ label: 'Role', val: role });
+
+      // Session plays (if currently on the deck)
+      if (firetable.tableData) {
+        for (var k in firetable.tableData) {
+          if (firetable.tableData.hasOwnProperty(k) && firetable.tableData[k].id === userid) {
+            facts.push({ label: 'Session plays', val: firetable.tableData[k].plays });
+            break;
+          }
+        }
+      }
+
+      // Audio broadcasting
+      if (userData.idle && userData.idle.audio === 2) {
+        facts.push({ label: 'Audio', val: 'Broadcasting' });
+      }
+
+      // Cards (async — placeholder first)
+      facts.push({ label: 'Cards', val: '<span class="utt-cards-val">…</span>' });
+
+      var factsHtml = facts.map(function (f) {
+        return '<div class="utt-fact"><span class="utt-label">' + f.label + '</span><span class="utt-val">' + f.val + '</span></div>';
+      }).join('');
+
+      $userTip.find('.utt-facts').html(factsHtml);
+      $userTip.attr('data-for', userid);
+
+      // >1024px: tooltip on the right; <=1024px: tooltip on the left
+      var placement = window.matchMedia('(min-width: 1024px)').matches ? 'right' : 'left';
+
+      userTipEl.style.visibility = 'hidden';
+      $userTip.addClass('is-visible');
+
+      FloatingUIDOM.computePosition(anchorEl, userTipEl, {
+        placement: placement,
+        strategy: 'fixed',
+        middleware: [
+          FloatingUIDOM.offset(8),
+          FloatingUIDOM.flip(),
+          FloatingUIDOM.shift({ padding: 8 }),
+          FloatingUIDOM.arrow({ element: userTipArrowEl, padding: 4 })
+        ]
+      }).then(function (pos) {
+        userTipEl.style.left = pos.x + 'px';
+        userTipEl.style.top  = pos.y + 'px';
+
+        // Arrow positioning
+        if (pos.middlewareData.arrow) {
+          var ax = pos.middlewareData.arrow.x;
+          var ay = pos.middlewareData.arrow.y;
+          var staticSide = { top: 'bottom', bottom: 'top', left: 'right', right: 'left' }[pos.placement.split('-')[0]];
+          Object.assign(userTipArrowEl.style, {
+            left:         ax != null ? ax + 'px' : '',
+            top:          ay != null ? ay + 'px' : '',
+            right:        '',
+            bottom:       '',
+            [staticSide]: '-4px'
+          });
+        }
+
+        userTipEl.style.visibility = 'visible';
+      });
+
+      // Resolve card count
+      if (_cardCountCache.hasOwnProperty(userid)) {
+        $userTip.find('.utt-cards-val').text(_cardCountCache[userid]);
+      } else {
+        firebase.app("firetable").database().ref("cards")
+          .orderByChild('owner').equalTo(userid)
+          .once("value")
+          .then(function (snap) {
+            var count = snap.numChildren();
+            _cardCountCache[userid] = count;
+            if ($userTip.attr('data-for') === userid) {
+              $userTip.find('.utt-cards-val').text(count);
+            }
+          });
+      }
+    }
+
+    function hideUserTip() {
+      $userTip.removeClass('is-visible').removeAttr('data-for');
+    }
+
+    $('#allUsersWrap')
+      .on('mouseenter.ft-usertip', '.prson', function () {
+        var uid = $(this).attr('data-userid');
+        if (uid) showUserTip(this, uid);
+      })
+      .on('mouseleave.ft-usertip', '.prson', hideUserTip);
   }
 
   return { bind: bind, show: show, hide: hide };

--- a/js/ui.js
+++ b/js/ui.js
@@ -275,61 +275,152 @@ firetable.ui.initSettings = function () {
  * modals, settings toggles, grab, volume, mini-mode, emoji picker, etc.
  * Called once from firetable.ui.init().
  */
-// ── Queue view navigation ──
-firetable.ui.showView = function (name, push) {
-  if (push !== false) {
-    var base = location.pathname.replace(/\/(playlists|history|cards|discover)\/?$/, '/').replace(/\/$/, '') + '/';
-    history.pushState({ view: name }, '', base + name);
-  }
-  var headerBtns = { playlists: '#playlists', history: '#history', cards: '#cardcase', discover: '#discover-nav' };
-  var miniTabs   = { playlists: '#mm-playlists', history: '#mm-history', cards: '#mm-cards', discover: '#mm-discover' };
-  // Drive visibility via CSS class, not inline styles, so media-query rules always win
-  $('#mainGrid').removeClass('view-playlists view-history view-cards view-discover').addClass('view-' + name);
-  $.each(headerBtns, function (key, sel) {
-    $(sel).toggleClass('on', key === name);
-  });
-  $.each(miniTabs, function (key, sel) {
-    $(sel).toggleClass('on', key === name);
-  });
-  if (name === 'cards') { firetable.actions.cardCase(); }
-};
 
-// ── Sync mini-nav active tab to current grid + view state ──
-// Called on init and whenever the viewport crosses the 640px breakpoint.
-firetable.ui.syncNavState = function () {
-  var isWide = window.matchMedia('(min-width: 640px)').matches;
-  var $grid  = $('#mainGrid');
-  if (isWide) {
-    // At 640px+: mini-nav only shows People/Chat.
-    // Ensure exactly one of those two tabs is active.
-    $('#mm-playlists, #mm-history, #mm-cards, #mm-discover').removeClass('on');
-    var isMMusrs = $grid.hasClass('mmusrs');
-    $('#minimodeoptions #mmusrs').toggleClass('on', isMMusrs);
-    $('#minimodeoptions #mmchat').toggleClass('on', !isMMusrs);
-  } else {
-    // At mobile: 5-tab mini-nav must reflect grid-class + view-class.
-    $('#minimodeoptions .tab').removeClass('on');
-    if ($grid.hasClass('mmusrs')) {
-      $('#mmusrs').addClass('on');
-    } else if ($grid.hasClass('mmchat')) {
-      $('#mmchat').addClass('on');
-    } else if ($grid.hasClass('mmqueue')) {
-      var activeTab = $grid.hasClass('view-history')  ? 'mm-history'
-                    : $grid.hasClass('view-cards')    ? 'mm-cards'
-                    : $grid.hasClass('view-discover') ? 'mm-discover'
-                    :                                   'mm-playlists';
-      $('#' + activeTab).addClass('on');
+// ─── Navigation State ─────────────────────────────────────────────────────────
+// Tracks three independent pieces of state:
+//   view         – which content view is active (playlists|history|cards|discover)
+//   side         – which side panel is active at medium (chat|people)
+//   mobileSection – which group shows on mobile (view|chat|people)
+// All three are persisted to localStorage so refresh restores the exact state.
+
+firetable.nav = {
+  view: 'playlists',
+  side: 'chat',
+  mobileSection: 'view',
+
+  _validViews:   ['playlists', 'history', 'cards', 'discover'],
+  _validSides:   ['chat', 'people'],
+  _validMobile:  ['view', 'chat', 'people'],
+  _viewTabMap:   { playlists: 'mm-playlists', history: 'mm-history', cards: 'mm-cards', discover: 'mm-discover' },
+
+  /** Persist current state to localStorage. */
+  save: function () {
+    localStorage[STORAGE.navView]   = firetable.nav.view;
+    localStorage[STORAGE.navSide]   = firetable.nav.side;
+    localStorage[STORAGE.navMobile] = firetable.nav.mobileSection;
+  },
+
+  /** Restore state from URL path (backward compat) then localStorage. */
+  restore: function () {
+    var n = firetable.nav;
+    // URL path takes priority for viewNav (handles old bookmarks / shared links)
+    var pathMatch = location.pathname.match(/\/(playlists|history|cards|discover)\/?$/);
+    if (pathMatch) {
+      n.view = pathMatch[1];
+      n.mobileSection = 'view';
+      // Clean up the URL so it doesn't look like we still do path-based routing
+      history.replaceState(null, '', location.pathname.replace(/\/(playlists|history|cards|discover)\/?$/, '/'));
     } else {
-      // No matching layout class — default to people.
-      $grid.addClass('mmusrs');
-      $('#mmusrs').addClass('on');
+      var sv = localStorage[STORAGE.navView];
+      if (sv && n._validViews.indexOf(sv) !== -1) n.view = sv;
     }
+    var ss = localStorage[STORAGE.navSide];
+    if (ss && n._validSides.indexOf(ss) !== -1) n.side = ss;
+
+    var sm = localStorage[STORAGE.navMobile];
+    if (sm && n._validMobile.indexOf(sm) !== -1) n.mobileSection = sm;
+
+    n.save();
+  },
+
+  /** Set the active content view. */
+  setView: function (name) {
+    firetable.nav.view = name;
+    firetable.nav.mobileSection = 'view';
+    firetable.nav.save();
+    firetable.nav.apply();
+  },
+
+  /** Set the active side panel (chat or people). */
+  setSide: function (name) {
+    firetable.nav.side = name;
+    firetable.nav.mobileSection = name; // 'chat' or 'people'
+    firetable.nav.save();
+    firetable.nav.apply();
+  },
+
+  /** Handle a mini-mode tab click by its element ID. */
+  setMobileTab: function (tabId) {
+    var n = firetable.nav;
+    var viewMap = { 'mm-playlists': 'playlists', 'mm-history': 'history', 'mm-cards': 'cards', 'mm-discover': 'discover' };
+    if (viewMap[tabId]) {
+      n.view = viewMap[tabId];
+      n.mobileSection = 'view';
+    } else if (tabId === 'mmchat') {
+      n.side = 'chat';
+      n.mobileSection = 'chat';
+    } else if (tabId === 'mmusrs') {
+      n.side = 'people';
+      n.mobileSection = 'people';
+    }
+    n.save();
+    n.apply();
+  },
+
+  /** Apply the current nav state to the DOM based on viewport size. */
+  apply: function () {
+    var n    = firetable.nav;
+    var $g   = $('#mainGrid');
+    var isLg = window.matchMedia('(min-width: 1024px)').matches;
+    var isMd = window.matchMedia('(min-width: 640px)').matches;
+
+    // ── View class (always) ──
+    $g.removeClass('view-playlists view-history view-cards view-discover')
+      .addClass('view-' + n.view);
+
+    // ── Header buttons (visible at 640px+) ──
+    $('#playlists').toggleClass('on',    n.view === 'playlists');
+    $('#history').toggleClass('on',      n.view === 'history');
+    $('#cardcase').toggleClass('on',     n.view === 'cards');
+    $('#discover-nav').toggleClass('on', n.view === 'discover');
+
+    // ── Layout classes ──
+    $g.removeClass('mmqueue mmchat mmusrs');
+
+    if (isLg) {
+      // 1024px+: chat AND people always visible (CSS overrides).
+      // Still set a layout class so resizing down transitions smoothly.
+      $g.addClass(n.side === 'people' ? 'mmusrs' : 'mmchat');
+    } else if (isMd) {
+      // 640px–1023px: side panel = chat or people
+      $g.addClass(n.side === 'people' ? 'mmusrs' : 'mmchat');
+      // Mini-mode shows only Chat / People tabs at this size
+      $('#minimodeoptions .tab').removeClass('on');
+      $('#mmusrs').toggleClass('on', n.side === 'people');
+      $('#mmchat').toggleClass('on',  n.side === 'chat');
+    } else {
+      // Mobile: one panel at a time
+      if (n.mobileSection === 'people') {
+        $g.addClass('mmusrs');
+      } else if (n.mobileSection === 'chat') {
+        $g.addClass('mmchat');
+      } else {
+        $g.addClass('mmqueue');
+      }
+      // Mini-mode shows all 6 tabs
+      $('#minimodeoptions .tab').removeClass('on');
+      if (n.mobileSection === 'people') {
+        $('#mmusrs').addClass('on');
+      } else if (n.mobileSection === 'chat') {
+        $('#mmchat').addClass('on');
+      } else {
+        $('#' + n._viewTabMap[n.view]).addClass('on');
+      }
+    }
+
+    if (n.view === 'cards') firetable.actions.cardCase();
   }
 };
 
+// ── Backward-compat wrapper so any remaining showView calls still work ──
+firetable.ui.showView = function (name) {
+  firetable.nav.setView(name);
+};
+firetable.ui.syncNavState = function () {
+  firetable.nav.apply();
+};
 firetable.ui.getViewFromPath = function () {
-  var m = location.pathname.match(/\/(playlists|history|cards|discover)\/?$/);
-  return (m && m[1]) || 'playlists';
+  return firetable.nav.view;
 };
 
 firetable.ui.updateScreenBtn = function (val) {
@@ -426,35 +517,24 @@ firetable.ui.setupMiscEvents = function () {
 
   // ── Mini mode discover/login tabs (pre-login only) ──
   $("#minidiscover").bind("click", function () {
-    firetable.ui.showView('discover');
+    firetable.nav.setView('discover');
   });
   $("#minijoin").bind("click", function () {
-    firetable.ui.showView('playlists');
+    firetable.nav.setView('playlists');
   });
 
   // ── Mini-mode tabs ──
   $("#minimodeoptions .tab").bind("click", function () {
-    var tabId = $(this).attr('id');
-    var viewTabs = ['mm-playlists', 'mm-history', 'mm-cards', 'mm-discover'];
-    var gridClass = (viewTabs.indexOf(tabId) !== -1) ? 'mmqueue' : tabId;
-    // Only swap the layout class (mmusrs/mmchat/mmqueue); preserve view-* class
-    // so the CSS view-class rules work correctly across breakpoints
-    $("#mainGrid").removeClass('mmusrs mmchat mmqueue').addClass(gridClass);
-    $("#minimodeoptions .tab").removeClass('on');
-    $(this).addClass('on');
-    if (tabId === 'mm-playlists') {
-      firetable.ui.showView('playlists');
-    } else if (tabId === 'mm-history') {
-      firetable.ui.showView('history');
-    } else if (tabId === 'mm-cards') {
-      firetable.ui.showView('cards');
-    } else if (tabId === 'mm-discover') {
-      firetable.ui.showView('discover');
-    }
+    firetable.nav.setMobileTab($(this).attr('id'));
   });
 
-  // ── Sync nav tabs on breakpoint change ──
-  window.matchMedia('(min-width: 640px)').addEventListener('change', firetable.ui.syncNavState);
+  // ── Re-apply nav state when crossing breakpoints ──
+  window.matchMedia('(min-width: 640px)').addEventListener('change', function () {
+    firetable.nav.apply();
+  });
+  window.matchMedia('(min-width: 1024px)').addEventListener('change', function () {
+    firetable.nav.apply();
+  });
 
   // ── Grab (steal to another playlist) ──
   $("#grab").bind("click", function () {
@@ -522,13 +602,14 @@ firetable.ui.setupMiscEvents = function () {
   });
 
   $(window).on('popstate', function () {
-    firetable.ui.showView(firetable.ui.getViewFromPath(), false);
+    firetable.nav.restore();
+    firetable.nav.apply();
   });
 
-  $("#history").bind("click", function () { firetable.ui.showView('history'); });
+  $("#history").bind("click", function () { firetable.nav.setView('history'); });
 
   // ── Playlists button toggle ──
-  $("#playlists").bind("click", function () { firetable.ui.showView('playlists'); });
+  $("#playlists").bind("click", function () { firetable.nav.setView('playlists'); });
 
   // ── Reload Track ──
   $("#reloadtrack").bind("click", firetable.actions.reloadtrack);
@@ -578,10 +659,10 @@ firetable.ui.setupMiscEvents = function () {
   });
 
   // ── Card Case panel ──
-  $("#cardcase").bind("click", function () { firetable.ui.showView('cards'); });
+  $("#cardcase").bind("click", function () { firetable.nav.setView('cards'); });
 
   // ── Discover / Fresh Produce panel ──
-  $("#discover-nav").bind("click", function () { firetable.ui.showView('discover'); });
+  $("#discover-nav").bind("click", function () { firetable.nav.setView('discover'); });
 
   // ── Emoji Picker ──
   $("#pickerNav").on("click", "span", function () {
@@ -821,11 +902,9 @@ firetable.ui.init = function () {
   firetable.ui.setupRoomEvents();
   firetable.ui.setupMiscEvents();
 
-  // Restore active view from URL path on initial load
-  firetable.ui.showView(firetable.ui.getViewFromPath(), false);
-
-  // Sync mini-nav active tab to match current viewport
-  firetable.ui.syncNavState();
+  // Restore nav state from URL / localStorage and apply to DOM
+  firetable.nav.restore();
+  firetable.nav.apply();
 
   // Start drag-and-drop link detection
   firetable.ui.LinkGrabber.start();

--- a/js/ui.js
+++ b/js/ui.js
@@ -505,6 +505,17 @@ firetable.ui.tooltip = (function () {
       $el.attr('title', $el.attr('data-ft-title')).removeAttr('data-ft-title');
       hide();
     });
+
+    // ── User list: title-based tooltips ──
+    $('#allUsersWrap').on('mouseenter.ft-tooltip', '[title]', function () {
+      var $el = $(this), text = $el.attr('title');
+      $el.attr('data-ft-title', text).removeAttr('title');
+      show(this, text);
+    }).on('mouseleave.ft-tooltip', '[data-ft-title]', function () {
+      var $el = $(this);
+      $el.attr('title', $el.attr('data-ft-title')).removeAttr('data-ft-title');
+      hide();
+    });
   }
 
   return { bind: bind, show: show, hide: hide };

--- a/js/ui.js
+++ b/js/ui.js
@@ -601,6 +601,15 @@ firetable.ui.tooltip = (function () {
         userTipEl.style.visibility = 'visible';
       });
 
+      // Mod/supermod actions
+      var ownUser = ftapi.uid && ftapi.users && ftapi.users[ftapi.uid];
+      var isMod = ownUser && (ownUser.mod || ownUser.supermod);
+      var actionsHtml = '';
+      if (isMod && userid !== ftapi.uid) {
+        actionsHtml = '<button class="utt-action-btn" data-action="add-to-deck">Add to deck</button>';
+      }
+      $userTip.find('.utt-actions').html(actionsHtml);
+
       // Resolve card count
       if (_cardCountCache.hasOwnProperty(userid)) {
         $userTip.find('.utt-cards-val').text(_cardCountCache[userid]);
@@ -618,16 +627,34 @@ firetable.ui.tooltip = (function () {
       }
     }
 
-    function hideUserTip() {
-      $userTip.removeClass('is-visible').removeAttr('data-for');
+    var _hideTimer = null;
+    function scheduleHideUserTip() {
+      _hideTimer = setTimeout(function () {
+        $userTip.removeClass('is-visible').removeAttr('data-for');
+      }, 150);
     }
+    function cancelHideUserTip() {
+      clearTimeout(_hideTimer);
+    }
+
+    $(userTipEl)
+      .on('mouseenter', cancelHideUserTip)
+      .on('mouseleave', scheduleHideUserTip)
+      .on('click', '[data-action="add-to-deck"]', function () {
+        var uid = $userTip.attr('data-for');
+        var userData = uid && ftapi.users && ftapi.users[uid];
+        if (userData && userData.username) {
+          ftapi.actions.sendBotCommand('!add ' + userData.username);
+        }
+      });
 
     $('#allUsersWrap')
       .on('mouseenter.ft-usertip', '.prson', function () {
+        cancelHideUserTip();
         var uid = $(this).attr('data-userid');
         if (uid) showUserTip(this, uid);
       })
-      .on('mouseleave.ft-usertip', '.prson', hideUserTip);
+      .on('mouseleave.ft-usertip', '.prson', scheduleHideUserTip);
   }
 
   return { bind: bind, show: show, hide: hide };

--- a/js/ui.js
+++ b/js/ui.js
@@ -260,6 +260,18 @@ firetable.ui.initSettings = function () {
   }
   firetable.ui.updateScreenBtn(firetable.screenControl);
 
+  // ── Share Typing Status ──
+  var shareTyping = localStorage[STORAGE.shareTyping];
+  if (typeof shareTyping == "undefined") {
+    localStorage[STORAGE.shareTyping] = true;
+    firetable.shareTyping = true;
+    $("#shareTypingToggle").prop("checked", true);
+  } else {
+    shareTyping = JSON.parse(shareTyping);
+    firetable.shareTyping = shareTyping;
+    $("#shareTypingToggle").prop("checked", shareTyping);
+  }
+
   // ── Avatar Style ──
   var savedAvatarStyle = localStorage[STORAGE.avatarStyle];
   if (savedAvatarStyle) {
@@ -874,6 +886,13 @@ firetable.ui.setupMiscEvents = function () {
     firetable.debug && console.log("badoop " + (this.checked ? "on" : "off"));
     localStorage[STORAGE.badoop] = this.checked;
     firetable.playBadoop = this.checked;
+  });
+  $('#shareTypingToggle').change(function () {
+    localStorage[STORAGE.shareTyping] = this.checked;
+    firetable.shareTyping = this.checked;
+    if (ftapi.uid) {
+      firebase.app("firetable").database().ref("users/" + ftapi.uid + "/shareTyping").set(this.checked ? null : false);
+    }
   });
   $('#showImagesToggle').change(function () {
     firetable.debug && console.log("show images " + (this.checked ? "on" : "off"));

--- a/js/users.js
+++ b/js/users.js
@@ -346,7 +346,7 @@ function buildUserHTML(data) {
          '<span class="material-symbols-outlined blockon"' + (data.blocked ? ' title="You have blocked this user. They will not see your chats, and you will not see their chats."' : '') + '>' + blockcon + '</span>' +
          '</div>' +
          '<span class="' + roleiconclass + ' prsnRole">' + roleicon + '</span>' +
-         '<div class="prsnNameRole" title="Joined ' + firetable.utilities.format_date(data.joined) + '">' +
+         '<div class="prsnNameRole">' +
          '<span class="prsnName">' + data.username + '</span>' +
          '</div>';
 }
@@ -378,6 +378,7 @@ firetable.ui.setupUserEvents = function () {
     var $el = $("<div></div>")
       .addClass("prson" + (data.blocked ? " blockd" : "") + (isIdle ? " " + isIdle : ""))
       .attr("id", "user" + data.userid)
+      .attr("data-userid", data.userid)
       .html(buildUserHTML(data));
     firetable.utilities.chatAt($el);
     $(getUserDestination(data)).append($el);
@@ -416,6 +417,7 @@ firetable.ui.setupUserEvents = function () {
         var $el = $("<div></div>")
           .addClass("prson" + (data.blocked ? " blockd" : "") + (isIdle ? " " + isIdle : ""))
           .attr("id", "user" + uid)
+          .attr("data-userid", uid)
           .html(buildUserHTML(data));
         firetable.utilities.chatAt($el);
         $(getUserDestination(data)).append($el);

--- a/js/users.js
+++ b/js/users.js
@@ -343,7 +343,7 @@ function buildUserHTML(data) {
   if (data.hostbot) { roleicon = "smart_toy"; roleiconclass = "material-symbols-outlined"; }
 
   return '<div class="ft-avatar" style="background-image:url(' + firetable.utilities.avatarURL(data.userid, data.username, null, data.avatarStyle) + ');">' +
-         '<span class="material-symbols-outlined blockon"' + (data.blocked ? ' title="This user is blocked and cannot post in chat."' : '') + '>' + blockcon + '</span>' +
+         '<span class="material-symbols-outlined blockon"' + (data.blocked ? ' title="You have blocked this user. They will not see your chats, and you will not see their chats."' : '') + '>' + blockcon + '</span>' +
          '</div>' +
          '<span class="' + roleiconclass + ' prsnRole">' + roleicon + '</span>' +
          '<div class="prsnNameRole" title="Joined ' + firetable.utilities.format_date(data.joined) + '">' +

--- a/js/users.js
+++ b/js/users.js
@@ -151,9 +151,9 @@ firetable.actions.loggedIn = function (user) {
   $("#loggedInName").show();
   $("#logOutButton").show().on('click', firetable.actions.logOut);
   firetable.debug && console.log('remove login class from mainGrid');
-  $('#mainGrid').removeClass('login').removeClass('pre-auth').addClass('mmusrs');
-  firetable.ui.showView(firetable.ui.getViewFromPath(), false);
-  firetable.ui.syncNavState();
+  $('#mainGrid').removeClass('login').removeClass('pre-auth');
+  firetable.nav.restore();
+  firetable.nav.apply();
   $("#grab").css("display", "inline-block");
 };
 

--- a/js/users.js
+++ b/js/users.js
@@ -326,7 +326,7 @@ firetable.ui.loginLinkToggle = function (id) {
  * @returns {string} Inner HTML for the user row
  */
 function buildUserHTML(data) {
-  var blockcon = data.blocked ? "keyboard_off" : "";
+  var blockcon = data.blocked ? "block" : "";
   var herecon = "lens";
   var isIdle = "";
 
@@ -343,7 +343,7 @@ function buildUserHTML(data) {
   if (data.hostbot) { roleicon = "smart_toy"; roleiconclass = "material-symbols-outlined"; }
 
   return '<div class="ft-avatar" style="background-image:url(' + firetable.utilities.avatarURL(data.userid, data.username, null, data.avatarStyle) + ');">' +
-         '<span class="material-symbols-outlined blockon">' + blockcon + '</span>' +
+         '<span class="material-symbols-outlined blockon"' + (data.blocked ? ' title="This user is blocked and cannot post in chat."' : '') + '>' + blockcon + '</span>' +
          '</div>' +
          '<span class="' + roleiconclass + ' prsnRole">' + roleicon + '</span>' +
          '<div class="prsnNameRole" title="Joined ' + firetable.utilities.format_date(data.joined) + '">' +

--- a/js/users.js
+++ b/js/users.js
@@ -326,7 +326,7 @@ firetable.ui.loginLinkToggle = function (id) {
  * @returns {string} Inner HTML for the user row
  */
 function buildUserHTML(data) {
-  var blockcon = data.blocked ? "block" : "";
+  var blockcon = data.blocked ? "keyboard_off" : "";
   var herecon = "lens";
   var isIdle = "";
 

--- a/serve.json
+++ b/serve.json
@@ -2,6 +2,7 @@
   "rewrites": [
     { "source": "/playlists", "destination": "/index.html" },
     { "source": "/history", "destination": "/index.html" },
-    { "source": "/cards", "destination": "/index.html" }
+    { "source": "/cards", "destination": "/index.html" },
+    { "source": "/discover", "destination": "/index.html" }
   ]
 }


### PR DESCRIPTION
**Before → After**

| | Before | After |
|---|---|---|
| Writes to | `users/{uid}/typing`, `users/{uid}/shareTyping` | `typing/{uid}` only |
| Reads | Full `users/` node (fires on every user change) | `typing/` node only (tiny, typing-only data) |
| Rules needed | Additions inside existing `users/` rules | One new top-level path: `"typing": { "$uid": { ".read": "auth != null", ".write": "auth.uid === $uid" } }` |
| Share preference | Stored as separate Firebase field | Encoded in the value: `"username"` = sharing, `true` = anonymous |
| `_setShareTyping` | Had to write to `users/` | Eliminated entirely — no Firebase write on toggle |

The toggle handler now only touches `localStorage`/`firetable.shareTyping`. The preference takes effect on the next keypress when `_setTyping` decides whether to write the username or `true`.